### PR TITLE
Merge Resume global step checkpoint into master

### DIFF
--- a/scripts/caffe/convert_caffe_weights_to_npy.py
+++ b/scripts/caffe/convert_caffe_weights_to_npy.py
@@ -480,7 +480,7 @@ def main():
     proto = open(arch['DEPLOY_PROTOTXT']).readlines()
     for line in proto:
         for key, value in vars.items():
-            tag = "$%s$" % key
+            tag = "${}$".format(key)
             line = line.replace(tag, str(value))
         tmp.write(line)
     tmp.flush()

--- a/scripts/caffe/convert_npy_weights_to_tf.py
+++ b/scripts/caffe/convert_npy_weights_to_tf.py
@@ -27,7 +27,7 @@ def main():
         sess.run(tf.global_variables_initializer())
         input_name = os.path.splitext(FLAGS.input)[0]
         save_path = saver.save(sess, input_name + '.ckpt', global_step=global_step)
-        print("Model saved in file: %s" % save_path)
+        print("Model saved in file: {}".format(save_path))
 
 
 if __name__ == '__main__':

--- a/scripts/convert_fc_to_tfrecords.py
+++ b/scripts/convert_fc_to_tfrecords.py
@@ -3,7 +3,6 @@ import os
 import sys
 import numpy as np
 from progressbar import ProgressBar, Percentage, Bar
-# from scipy.misc import imread
 from imageio import imread
 import tensorflow as tf
 from math import ceil
@@ -146,10 +145,8 @@ def convert_dataset(indices, name, matcher='deepmatching', dataset='flying_chair
 
             if DEBUG:
                 print("Path to source images/flows are:")
-                print("img_a: {0}\nimg_b: {1}\nmch_a: {2}\nsp_flow: {3}\nflow: {4}\n".format(image_a_path, image_b_path,
-                                                                                             matches_a_path,
-                                                                                             sparse_flow_path,
-                                                                                             flow_path))
+                print("img_a: {0}\nimg_b: {1}\nmch_a: {2}\nsp_flow: {3}\nflow: {4}\n".format(
+                    image_a_path, image_b_path, matches_a_path, sparse_flow_path, flow_path))
 
             image_a = imread(image_a_path)
             image_b = imread(image_b_path)
@@ -258,7 +255,6 @@ def convert_dataset(indices, name, matcher='deepmatching', dataset='flying_chair
             writer.write(tf_example.SerializeToString())
             pbar.update(count + 1)
             count += 1
-    # writer.close()
 
 
 def main():

--- a/scripts/convert_fc_to_tfrecords.py
+++ b/scripts/convert_fc_to_tfrecords.py
@@ -92,15 +92,15 @@ def convert_dataset(indices, name, matcher='deepmatching', dataset='flying_chair
                     Also, we follow FlowNet2.0 training and discard a set of difficult sequences (1388, to be precise)
                 """
                 print("Setting format for 'FlyingThings3D'...")
-                image_a_path = os.path.join(FLAGS.data_dir, '{0:05d}_img1.webp'.format(i + 1))
-                image_b_path = os.path.join(FLAGS.data_dir, '{0:05d}_img2.webp'.format(i + 1))
-                flow_path = os.path.join(FLAGS.data_dir, '{0:05d}_flow.flo'.format(i + 1))
+                image_a_path = os.path.join(FLAGS.data_dir, '{0:07d}.png'.format(i))
+                image_b_path = os.path.join(FLAGS.data_dir, '{0:07d}.png'.format(i + 1))
+                flow_path = os.path.join(FLAGS.data_dir, '{0:07d}.flo'.format(i))
                 if matcher == 'sift':
-                    matches_a_path = os.path.join(FLAGS.data_dir, '{0:05d}_img1_sift_mask.png'.format(i + 1))
-                    sparse_flow_path = os.path.join(FLAGS.data_dir, '{0:05d}_img1_sift_sparse_flow.flo'.format(i + 1))
+                    matches_a_path = os.path.join(FLAGS.data_dir, '{0:07d}_sift_mask.png'.format(i))
+                    sparse_flow_path = os.path.join(FLAGS.data_dir, '{0:07d}_sift_sparse_flow.flo'.format(i))
                 elif matcher == 'deepmatching':
-                    matches_a_path = os.path.join(FLAGS.data_dir, '{0:05d}_img1_dm_mask.png'.format(i + 1))
-                    sparse_flow_path = os.path.join(FLAGS.data_dir, '{0:05d}_img1_dm_sparse_flow.flo'.format(i + 1))
+                    matches_a_path = os.path.join(FLAGS.data_dir, '{0:07d}_dm_mask.png'.format(i))
+                    sparse_flow_path = os.path.join(FLAGS.data_dir, '{0:07d}_dm_sparse_flow.flo'.format(i))
                 # add more matchers if need be (more elif's)
                 else:
                     raise ValueError("Invalid matcher name. Available: ('deepmatching', 'sift')")
@@ -124,6 +124,22 @@ def convert_dataset(indices, name, matcher='deepmatching', dataset='flying_chair
 
             elif dataset == 'sintel_final':
                 print("Setting format for 'MPI-Sintel (final pass)'...")
+                pass_dir = 'final'
+                image_a_path = os.path.join(FLAGS.data_dir, pass_dir, 'frame_{0:04d}.png'.format(i+1))
+                image_b_path = os.path.join(FLAGS.data_dir, pass_dir, 'frame_{0:04d}.png'.format(i+2))
+                flow_path = os.path.join(FLAGS.data_dir, pass_dir, 'frame_{0:04d}.flo'.format(i+1))
+                if matcher == 'sift':
+                    matches_a_path = os.path.join(FLAGS.data_dir, pass_dir, 'frame_{0:04d}_sift_mask.png'.format(i+1))
+                    sparse_flow_path = os.path.join(FLAGS.data_dir, pass_dir,
+                                                    'frame_{0:04d}_sift_sparse_flow.flo'.format(i+1))
+                elif matcher == 'deepmatching':
+                    matches_a_path = os.path.join(FLAGS.data_dir, pass_dir, 'frame_{0:04d}_dm_mask.png'.format(i+1))
+                    sparse_flow_path = os.path.join(FLAGS.data_dir, pass_dir,
+                                                    'frame_{0:04d}_dm_sparse_flow.flo'.format(i+1))
+                else:
+                    raise ValueError("Invalid matcher name. Available: ('deepmatching', 'sift')")
+            elif dataset == 'sintel_all':
+                print("Setting format for 'MPI-Sintel (final + clean pass)'...")
                 pass_dir = 'final'
                 image_a_path = os.path.join(FLAGS.data_dir, pass_dir, 'frame_{0:04d}.png'.format(i+1))
                 image_b_path = os.path.join(FLAGS.data_dir, pass_dir, 'frame_{0:04d}.png'.format(i+2))
@@ -284,6 +300,11 @@ def main():
         train_name = 'sintel_final_train_all'
         val_name = 'sintel_final_val_all'
         set_name = 'sintel_final'
+    elif 'sintel_all' in FLAGS.data_dir.lower() or FLAGS.dataset.lower() == 'sintel_all':
+        print("Chosen dataset is 'MPI-Sintel (final + clean pass)'")
+        train_name = 'sintel_train_all'
+        val_name = 'sintel_val_all'
+        set_name = 'sintel'
     # Add more datasets here (to change the final tfrecords name)
     # elif 'set_name' in FLAGS.data_dir:
     else:

--- a/scripts/convert_fc_to_tfrecords.py
+++ b/scripts/convert_fc_to_tfrecords.py
@@ -304,7 +304,7 @@ def main():
         print("Chosen dataset is 'MPI-Sintel (final + clean pass)'")
         train_name = 'sintel_train_all'
         val_name = 'sintel_val_all'
-        set_name = 'sintel'
+        set_name = 'sintel_all'
     # Add more datasets here (to change the final tfrecords name)
     # elif 'set_name' in FLAGS.data_dir:
     else:

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -81,18 +81,16 @@ def __get_dataset(dataset_config, split_name, input_type='image_pairs'):
     dataset_config: A dataset_config defined in dataset_configs.py
     split_name: 'train'/'validate'
     """
-    print("_get_dataset input_type: {0}".format(input_type))
     with tf.name_scope('__get_dataset'):
         if split_name not in dataset_config['SIZES']:
-            raise ValueError('split name %s not recognized' % split_name)
+            raise ValueError('split name {} not recognized'.format(split_name))
 
         # Width and height accounting for needed padding to match network dimensions
-        IMAGE_HEIGHT, IMAGE_WIDTH = dataset_config['PADDED_IMAGE_HEIGHT'], dataset_config['PADDED_IMAGE_WIDTH']
+        image_height, image_width = dataset_config['PADDED_IMAGE_HEIGHT'], dataset_config['PADDED_IMAGE_WIDTH']
         reader = tf.TFRecordReader
         if input_type == 'image_matches':
             keys_to_features = {
                 'image_a': tf.FixedLenFeature([], tf.string),
-                'image_b': tf.FixedLenFeature([], tf.string),
                 'matches_a': tf.FixedLenFeature([], tf.string),
                 'sparse_flow': tf.FixedLenFeature([], tf.string),  # initial sparse flow (from matches)
                 'flow': tf.FixedLenFeature([], tf.string),
@@ -101,27 +99,22 @@ def __get_dataset(dataset_config, split_name, input_type='image_pairs'):
                 'image_a': Image(
                     image_key='image_a',
                     dtype=tf.float64,
-                    shape=[IMAGE_HEIGHT, IMAGE_WIDTH, 3],
-                    channels=3),
-                'image_b': Image(
-                    image_key='image_b',
-                    dtype=tf.float64,
-                    shape=[IMAGE_HEIGHT, IMAGE_WIDTH, 3],
+                    shape=[image_height, image_width, 3],
                     channels=3),
                 'matches_a': Image(
                     image_key='matches_a',
                     dtype=tf.float64,
-                    shape=[IMAGE_HEIGHT, IMAGE_WIDTH, 1],
+                    shape=[image_height, image_width, 1],
                     channels=1),
                 'sparse_flow': Image(
                     image_key='sparse_flow',
                     dtype=tf.float32,
-                    shape=[IMAGE_HEIGHT, IMAGE_WIDTH, 2],
+                    shape=[image_height, image_width, 2],
                     channels=2),
                 'flow': Image(
                     image_key='flow',
                     dtype=tf.float32,
-                    shape=[IMAGE_HEIGHT, IMAGE_WIDTH, 2],
+                    shape=[image_height, image_width, 2],
                     channels=2),
             }
         else:
@@ -134,17 +127,17 @@ def __get_dataset(dataset_config, split_name, input_type='image_pairs'):
                 'image_a': Image(
                     image_key='image_a',
                     dtype=tf.float64,
-                    shape=[IMAGE_HEIGHT, IMAGE_WIDTH, 3],
+                    shape=[image_height, image_width, 3],
                     channels=3),
                 'image_b': Image(
                     image_key='image_b',
                     dtype=tf.float64,
-                    shape=[IMAGE_HEIGHT, IMAGE_WIDTH, 3],
+                    shape=[image_height, image_width, 3],
                     channels=3),
                 'flow': Image(
                     image_key='flow',
                     dtype=tf.float32,
-                    shape=[IMAGE_HEIGHT, IMAGE_WIDTH, 2],
+                    shape=[image_height, image_width, 2],
                     channels=2),
             }
 
@@ -257,7 +250,7 @@ def _generate_coeff(param, discount_coeff=tf.constant(1.0), default_value=tf.con
             tmp1 = tf.exp(tmp1)
         value = tmp1
     else:
-        raise ValueError('Unknown distribution type %s.' % rand_type)
+        raise ValueError('Unknown distribution type {}.'.format(rand_type))
     return value
 
 
@@ -274,7 +267,6 @@ def load_batch(dataset_config_str, split_name, global_step, input_type='image_pa
     elif dataset_config_str.lower() == 'sintel_clean':
         dataset_config = SINTEL_FINAL_ALL_DATASET_CONFIG  # must create tfrecords!
     elif dataset_config_str.lower() == 'sintel_final':
-        print("dataset_config is 'sintel_final' (OK)")
         dataset_config = SINTEL_FINAL_ALL_DATASET_CONFIG
     else:  # flying_chairs
         dataset_config = FLYING_CHAIRS_ALL_DATASET_CONFIG
@@ -293,7 +285,14 @@ def load_batch(dataset_config_str, split_name, global_step, input_type='image_pa
         if input_type == 'image_matches':
             image_b = None
             image_a, matches_a, sparse_flow, flow = data_provider.get(['image_a', 'matches_a', 'sparse_flow', 'flow'])
+            print("Checking if conversion is really necessary")
+            print("batches have type:")
+            print("type(image_a[0]): {}, type(matches_a[0]): {}, type(sparse_flows[0]): {}, type(flow[0]): {}".format(
+                type(image_a[0]), type(matches_a[0]), type(sparse_flow[0]), type(flow[0])))
             image_a, matches_a, sparse_flow, flow = map(tf.to_float, [image_a, matches_a, sparse_flow, flow])
+            print("batches have type (after conversion with map function (heavy on ram):")
+            print("type(image_a[0]): {}, type(matches_a[0]): {}, type(sparse_flows[0]): {}, type(flow[0]): {}".format(
+                type(image_a[0]), type(matches_a[0]), type(sparse_flow[0]), type(flow[0])))
 
         else:
             matches_a = None
@@ -302,7 +301,6 @@ def load_batch(dataset_config_str, split_name, global_step, input_type='image_pa
             image_a, image_b, flow = map(tf.to_float, [image_a, image_b, flow])
 
         if dataset_config['PREPROCESS']['scale']:
-            print("Should NOT enter here, image content already normalised")  # for debugging purposes only
             image_a = image_a / 255.0
             if not input_type == 'image_matches':
                 image_b = image_b / 255.0
@@ -405,10 +403,12 @@ def load_batch(dataset_config_str, split_name, global_step, input_type='image_pa
                                   enqueue_many=True,
                                   batch_size=dataset_config['BATCH_SIZE'],
                                   capacity=dataset_config['BATCH_SIZE'] * 4,
-                                  allow_smaller_final_batch=False)
+                                  allow_smaller_final_batch=False,
+                                  num_threads=num_threads)
         else:
             return tf.train.batch([image_as, image_bs, flows],
                                   enqueue_many=True,
                                   batch_size=dataset_config['BATCH_SIZE'],
                                   capacity=dataset_config['BATCH_SIZE'] * 4,
-                                  allow_smaller_final_batch=False)
+                                  allow_smaller_final_batch=False,
+                                  num_threads=num_threads)

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -4,6 +4,7 @@ import copy
 slim = tf.contrib.slim
 from math import exp
 from .dataset_configs import FLYING_CHAIRS_ALL_DATASET_CONFIG, SINTEL_FINAL_ALL_DATASET_CONFIG
+import resource
 
 _preprocessing_ops = tf.load_op_library(
     tf.resource_loader.get_path_to_datafile("./ops/build/preprocessing.so"))
@@ -275,16 +276,24 @@ def load_batch(dataset_config_str, split_name, global_step, input_type='image_pa
     reader_kwargs = {'options': tf.python_io.TFRecordOptions(tf.python_io.TFRecordCompressionType.ZLIB)}
     with tf.name_scope('load_batch'):
         dataset = __get_dataset(dataset_config, split_name, input_type=input_type)
+        mem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        print("(after __get_dataset function) Memory usage is: {0} GB".format(mem / 1e6))
         data_provider = slim.dataset_data_provider.DatasetDataProvider(
             dataset,
             num_readers=num_threads,
             common_queue_capacity=512,  # this also broke training, we lowered it (og. value = 2048)
             common_queue_min=256,  # this also broke training, we lowered it (og. value = 1024)
             reader_kwargs=reader_kwargs)
+        mem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        print("(after creating dataset_provider) Memory usage is: {0} GB".format(mem / 1e6))
 
         if input_type == 'image_matches':
             image_b = None
             image_a, matches_a, sparse_flow, flow = data_provider.get(['image_a', 'matches_a', 'sparse_flow', 'flow'])
+
+            mem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+            print("(after getting data from_provider(.get)) Memory usage is: {0} GB".format(mem / 1e6))
+
             print("Checking if conversion is really necessary")
             print("batches have type:")
             print("type(image_a[0]): {}, type(matches_a[0]): {}, type(sparse_flows[0]): {}, type(flow[0]): {}".format(
@@ -293,6 +302,9 @@ def load_batch(dataset_config_str, split_name, global_step, input_type='image_pa
             print("batches have type (after conversion with map function (heavy on ram):")
             print("type(image_a[0]): {}, type(matches_a[0]): {}, type(sparse_flows[0]): {}, type(flow[0]): {}".format(
                 type(image_a[0]), type(matches_a[0]), type(sparse_flow[0]), type(flow[0])))
+
+            mem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+            print("(after casting batch to float with 'map()') Memory usage is: {0} GB".format(mem / 1e6))
 
         else:
             matches_a = None
@@ -312,8 +324,12 @@ def load_batch(dataset_config_str, split_name, global_step, input_type='image_pa
 
         if input_type == 'image_matches':
             image_bs = None
+            mem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+            print("(before expanding dims of each tensor tf.expand_dims) Memory usage is: {0} GB".format(mem / 1e6))
             image_as, matches_as, sparse_flows, flows = map(lambda x: tf.expand_dims(x, 0),
                                                             [image_a, matches_a, sparse_flow, flow])
+            mem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+            print("(after expanding dims of each tensor tf.expand_dims) Memory usage is: {0} GB".format(mem / 1e6))
         else:
             matches_as = None
             sparse_flows = None

--- a/src/dataset_configs.py
+++ b/src/dataset_configs.py
@@ -177,8 +177,8 @@ FLYING_CHAIRS_ALL_DATASET_CONFIG = {
     },
     'BATCH_SIZE': 8,
     'PATHS': {
-        'train': './data/tfrecords/interp/fc_train_all.tfrecord',  # './data/tfrecords/fc_train_all.tfrecords',
-        'validate': './data/tfrecords/interp/fc_val_all.tfrecord',  #: './data/tfrecords/fc_val_all.tfrecords',
+        'train': '/datasets/GPI/optical_flow/TFrecords/interp/fc_train_all.tfrecord',
+        'validate': '/datasets/GPI/optical_flow/TFrecords/interp/fc_val_all.tfrecord',
         'sample': './data/tfrecords/fc_sample_all.tfrecords'  # does not exist (ignore)
     },
     'PREPROCESS': {
@@ -302,8 +302,8 @@ SINTEL_FINAL_ALL_DATASET_CONFIG = {
     },
     'BATCH_SIZE': 4,
     'PATHS': {
-        'train': './data/tfrecords/interp/sintel_final_train_all.tfrecord',
-        'validate': './data/tfrecords/interp/sintel_final_val_all.tfrecord',
+        'train': '/datasets/GPI/optical_flow/TFrecords/interp/sintel_final_train_all.tfrecord',
+        'validate': '/datasets/GPI/optical_flow/TFrecords/interp/sintel_final_val_all.tfrecord',
         'sample': './data/tfrecords/fc_sample_all.tfrecords'  # does not exist (ignore)
     },
     'PREPROCESS': {

--- a/src/dataset_configs.py
+++ b/src/dataset_configs.py
@@ -281,9 +281,134 @@ FLYING_CHAIRS_ALL_DATASET_CONFIG = {
         }
     }
 }
+
+# FlyingThings3D
+FLYING_THINGS_3D_ALL_DATASET_CONFIG = {
+    'IMAGE_HEIGHT': 384,
+    'IMAGE_WIDTH': 512,
+    'PADDED_IMAGE_HEIGHT': 384,
+    'PADDED_IMAGE_WIDTH': 768,
+    'ITEMS_TO_DESCRIPTIONS': {
+        'image_a': 'A 3-channel image.',
+        'image_b': 'A 3-channel image.',
+        'matches_a': 'A 1-channel matching mask (1s pixels matched, 0s not matched).',
+        'sparse_flow': 'A sparse flow initialised from a set of sparse matches.',
+        'flow': 'A 2-channel optical flow field.',
+    },
+    'SIZES': {
+        'train': 21817,
+        'validate': 4247,
+        'sample': 8,
+    },
+    'BATCH_SIZE': 4,
+    'PATHS': {
+        'train': '/datasets/GPI/optical_flow/TFrecords/interp/ft3d_train_all.tfrecord',
+        'validate': '/datasets/GPI/optical_flow/TFrecords/interp/ft3d_val_all.tfrecord',
+        'sample': './data/tfrecords/fc_sample_all.tfrecords'  # does not exist (ignore)
+    },
+    'PREPROCESS': {
+        'scale': False,
+        'crop_height': 384,
+        'crop_width': 768,
+        'image_a': {
+            'translate': {
+                'rand_type': "uniform_bernoulli",
+                'exp': False,
+                'mean': 0,
+                'spread': 0.4,
+                'prob': 1.0,
+            },
+            'rotate': {
+                'rand_type': "uniform_bernoulli",
+                'exp': False,
+                'mean': 0,
+                'spread': 0.4,
+                'prob': 1.0,
+            },
+            'zoom': {
+                'rand_type': "uniform_bernoulli",
+                'exp': True,
+                'mean': 0.2,
+                'spread': 0.4,
+                'prob': 1.0,
+            },
+            'squeeze': {
+                'rand_type': "uniform_bernoulli",
+                'exp': True,
+                'mean': 0,
+                'spread': 0.3,
+                'prob': 1.0,
+            },
+            'noise': {
+                'rand_type': "uniform_bernoulli",
+                'exp': False,
+                'mean': 0.03,
+                'spread': 0.03,
+                'prob': 1.0,
+            },
+        },
+        # All preprocessing to image A will be applied to image B in addition to the following.
+        'image_b': {
+            'translate': {
+                'rand_type': "gaussian_bernoulli",
+                'exp': False,
+                'mean': 0,
+                'spread': 0.03,
+                'prob': 1.0,
+            },
+            'rotate': {
+                'rand_type': "gaussian_bernoulli",
+                'exp': False,
+                'mean': 0,
+                'spread': 0.03,
+                'prob': 1.0,
+            },
+            'zoom': {
+                'rand_type': "gaussian_bernoulli",
+                'exp': True,
+                'mean': 0,
+                'spread': 0.03,
+                'prob': 1.0,
+            },
+            'gamma': {
+                'rand_type': "gaussian_bernoulli",
+                'exp': True,
+                'mean': 0,
+                'spread': 0.02,
+                'prob': 1.0,
+            },
+            'brightness': {
+                'rand_type': "gaussian_bernoulli",
+                'exp': False,
+                'mean': 0,
+                'spread': 0.02,
+                'prob': 1.0,
+            },
+            'contrast': {
+                'rand_type': "gaussian_bernoulli",
+                'exp': True,
+                'mean': 0,
+                'spread': 0.02,
+                'prob': 1.0,
+            },
+            'color': {
+                'rand_type': "gaussian_bernoulli",
+                'exp': True,
+                'mean': 0,
+                'spread': 0.02,
+                'prob': 1.0,
+            },
+            'coeff_schedule_param': {
+                'half_life': 50000,
+                'initial_coeff': 0.5,
+                'final_coeff': 1,
+            },
+        }
+    }
+}
 # Add here configs for other datasets. For instance, sintel/clean, sintel/final, slowflow, etc.
-# MPI-Sintel (Final pass only)
-SINTEL_FINAL_ALL_DATASET_CONFIG = {
+# MPI-Sintel (Final + clean pass)
+SINTEL_ALL_DATASET_CONFIG = {
     'IMAGE_HEIGHT': 436,
     'IMAGE_WIDTH': 1024,
     'PADDED_IMAGE_HEIGHT': 448,
@@ -296,19 +421,19 @@ SINTEL_FINAL_ALL_DATASET_CONFIG = {
         'flow': 'A 2-channel optical flow field.',
     },
     'SIZES': {
-        'train': 908,
+        'train': 1816,
         'validate': 133,
         'sample': 8,
     },
     'BATCH_SIZE': 4,
     'PATHS': {
-        'train': '/datasets/GPI/optical_flow/TFrecords/interp/sintel_final_train_all.tfrecord',
-        'validate': '/datasets/GPI/optical_flow/TFrecords/interp/sintel_final_val_all.tfrecord',
+        'train': '/datasets/GPI/optical_flow/TFrecords/interp/sintel_train_all.tfrecord',
+        'validate': '/datasets/GPI/optical_flow/TFrecords/interp/sintel_val_all.tfrecord',
         'sample': './data/tfrecords/fc_sample_all.tfrecords'  # does not exist (ignore)
     },
     'PREPROCESS': {
         'scale': False,
-        'crop_height': 320,
+        'crop_height': 384,
         'crop_width': 768,
         'image_a': {
             'translate': {

--- a/src/flowlib.py
+++ b/src/flowlib.py
@@ -263,7 +263,8 @@ def flow_to_image(flow):
     maxrad = max(-1, np.max(rad))
 
     if DEBUG:
-        print("max flow: %.4f\nflow range:\nu = %.3f .. %.3f\nv = %.3f .. %.3f" % (maxrad, minu, maxu, minv, maxv))
+        print("max flow: {.4f}\nflow range:\nu = {.3f} .. {.3f}\nv = {.3f} .. {.3f}".format(maxrad, minu, maxu, minv,
+                                                                                            maxv))
 
     u = u/(maxrad + np.finfo(float).eps)
     v = v/(maxrad + np.finfo(float).eps)

--- a/src/flownet_s_interp/train.py
+++ b/src/flownet_s_interp/train.py
@@ -1,6 +1,7 @@
 from ..dataloader import load_batch
 from .flownet_s_interp import FlowNetS_interp
 import argparse
+import resource
 
 # TODO: consider enabling training sequentially with several schedules with only one call to 'train'
 # TODO: should load previous checkpoint to properly resume training
@@ -9,7 +10,11 @@ import argparse
 
 def main():
     # Create a new network
+    mem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    print("(before initialising network) Memory usage is: {0} GB".format(mem/1e6))
     net = FlowNetS_interp()
+    mem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    print("(after initialising network) Memory usage is: {0} GB".format(mem/1e6))
     if FLAGS.checkpoint is not None:
         checkpoints = FLAGS.checkpoint  # we want to define it as a string (only one checkpoint to load)
     else:
@@ -17,8 +22,12 @@ def main():
 
     if FLAGS.input_type == 'image_matches':
         print("Input_type: 'image_matches'")
+        mem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        print("(before loading batches) Memory usage is: {0} GB".format(mem / 1e6))
         input_a, matches_a, sparse_flow, flow = load_batch(FLAGS.dataset_config, 'train', net.global_step,
                                                            input_type=FLAGS.input_type)
+        mem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        print("(after loading batches) Memory usage is: {0} GB".format(mem / 1e6))
 
         # Train on the data
         net.train(

--- a/src/net.py
+++ b/src/net.py
@@ -427,6 +427,21 @@ class Net(object):
 
     def train(self, log_dir, training_schedule_str, input_a, out_flow, input_b=None, matches_a=None, sparse_flow=None,
               checkpoints=None, input_type='image_pairs', log_verbosity=True):
+        # Add validation batches as input? Used only once every val_interval steps...?
+        """
+        runs training on the network from which this method is called.
+        :param log_dir:
+        :param training_schedule_str:
+        :param input_a:
+        :param out_flow:
+        :param input_b:
+        :param matches_a:
+        :param sparse_flow:
+        :param checkpoints:
+        :param input_type:
+        :param log_verbosity:
+        :return:
+        """
         if log_verbosity:  # print loss and tfinfo to stdout
             tf.logging.set_verbosity(tf.logging.INFO)
         # Otherwise, info only printed through TensorBoard

--- a/src/net.py
+++ b/src/net.py
@@ -623,7 +623,7 @@ class Net(object):
             total_loss,
             optimizer,
             summarize_gradients=False,
-            # global_step=self.global_step
+            global_step=self.global_step,
         )
 
         # Create unique logging dir to avoid overwritting of old data (e.g.: when comparing different runs)
@@ -658,6 +658,7 @@ class Net(object):
                     save_summaries_secs=180,
                     number_of_steps=training_schedule['max_iter'],
                     init_fn=InitAssignFn,
+                    # train_step_fn=train_step_fn,
                     # saver=saver,
                 )
             else:
@@ -668,6 +669,7 @@ class Net(object):
                     global_step=self.global_step,
                     save_summaries_secs=180,
                     number_of_steps=training_schedule['max_iter'],
+                    # train_step_fn=train_step_fn,
                     # saver=saver,
                 )
             print("Loss at the end of training is {}".format(final_loss))

--- a/src/net.py
+++ b/src/net.py
@@ -470,17 +470,20 @@ class Net(object):
                 variables_to_restore = slim.get_model_variables()
                 init_assign_op, init_feed_dict = slim.assign_from_checkpoint(
                     checkpoint_path, variables_to_restore)
-                updated_step = slim.get_or_create_global_step()
-                print("updated_step: {}".format(updated_step))
+                # updated_step = slim.get_or_create_global_step()
+                # print("updated_step: {}".format(updated_step))
                 print("self.global_step: {}".format(self.global_step))
 
-                # step_number = int(checkpoint_path.split('-')[-1])
-                # checkpoint_global_step_tensor = tf.Variable(step_number, trainable=False, name='global_step',
-                #                                             dtype='int64')
+                step_number = int(checkpoint_path.split('-')[-1])
+                checkpoint_global_step_tensor_2 = tf.Variable(step_number, trainable=False, name='global_step',
+                                                              dtype='int64')
                 checkpoint_global_step_tensor = slim.get_variables_by_name("global_step")[0]
                 print("checkpoint_global_step_tensor: {}".format(checkpoint_global_step_tensor))
+                print("checkpoint_global_step_tensor_2: {}".format(checkpoint_global_step_tensor_2))
                 self.global_step = checkpoint_global_step_tensor
                 print("self.global_step after assignment: {0}".format(self.global_step))
+                self.global_step = checkpoint_global_step_tensor_2
+                print("self.global_step_2 after assignment: {0}".format(self.global_step))
 
                 sess = tf.Session()
                 sess.run(self.global_step.initializer)
@@ -488,6 +491,9 @@ class Net(object):
                 sess.run(checkpoint_global_step_tensor.initializer)
                 print('self.checkpoint_global_step_tensor evaluated: {}'.format(tf.train.global_step(
                     sess, checkpoint_global_step_tensor)))
+                sess.run(checkpoint_global_step_tensor_2.initializer)
+                print('self.checkpoint_global_step_tensor_2 evaluated: {}'.format(tf.train.global_step(
+                    sess, checkpoint_global_step_tensor_2)))
                 # restorer = tf.train.Saver(checkpoint_global_step_tensor)
 
                 # with tf.Session() as sess:

--- a/src/net.py
+++ b/src/net.py
@@ -477,20 +477,20 @@ class Net(object):
                 step_number = int(checkpoint_path.split('-')[-1])
                 checkpoint_global_step_tensor_2 = tf.Variable(step_number, trainable=False, name='global_step',
                                                               dtype='int64')
-                checkpoint_global_step_tensor = slim.get_variables_by_name("global_step")[0]
-                print("checkpoint_global_step_tensor: {}".format(checkpoint_global_step_tensor))
+                # checkpoint_global_step_tensor = slim.get_variables_by_name("global_step")[0]
+                # print("checkpoint_global_step_tensor: {}".format(checkpoint_global_step_tensor))
                 print("checkpoint_global_step_tensor_2: {}".format(checkpoint_global_step_tensor_2))
-                self.global_step = checkpoint_global_step_tensor
-                print("self.global_step after assignment: {0}".format(self.global_step))
+                # self.global_step = checkpoint_global_step_tensor
+                # print("self.global_step after assignment: {0}".format(self.global_step))
                 self.global_step = checkpoint_global_step_tensor_2
                 print("self.global_step_2 after assignment: {0}".format(self.global_step))
 
                 sess = tf.Session()
                 sess.run(self.global_step.initializer)
                 print('self.global_step evaluated: {}'.format(tf.train.global_step(sess, self.global_step)))
-                sess.run(checkpoint_global_step_tensor.initializer)
-                print('self.checkpoint_global_step_tensor evaluated: {}'.format(tf.train.global_step(
-                    sess, checkpoint_global_step_tensor)))
+                # sess.run(checkpoint_global_step_tensor.initializer)
+                # print('self.checkpoint_global_step_tensor evaluated: {}'.format(tf.train.global_step(
+                #     sess, checkpoint_global_step_tensor)))
                 sess.run(checkpoint_global_step_tensor_2.initializer)
                 print('self.checkpoint_global_step_tensor_2 evaluated: {}'.format(tf.train.global_step(
                     sess, checkpoint_global_step_tensor_2)))

--- a/src/net.py
+++ b/src/net.py
@@ -5,6 +5,7 @@ import os
 import tensorflow as tf
 import numpy as np
 import glob
+import sys
 import datetime
 # from scipy.misc import imread, imsave
 import uuid
@@ -486,9 +487,11 @@ class Net(object):
                 #     restorer.restore(sess, checkpoint_path)
                 #     print("global_step: {}".format(global_step))
                 #     print("self.global_step: {}")
+
             else:
                 raise ValueError("checkpoint should be a single path (string) or a dictionary for stacked networks")
 
+        sys.stdout.flush()
         # Create an initial assignment function.
         def InitAssignFn(sess):
             sess.run(init_assign_op, init_feed_dict)

--- a/src/net.py
+++ b/src/net.py
@@ -445,6 +445,7 @@ class Net(object):
         if log_verbosity:  # print loss and tfinfo to stdout
             tf.logging.set_verbosity(tf.logging.INFO)
         # Otherwise, info only printed through TensorBoard
+        print("checkpoints: {}".format(checkpoints))
 
         # TODO: WIP read checkpoints first to try to correctly restore global_step as creating it breaks training
         # NOTE: everything depends on global_step to be correctly reported, that is why is critical to get it right

--- a/src/training_schedules.py
+++ b/src/training_schedules.py
@@ -37,8 +37,7 @@ SHORT_SCHEDULE = {
     'max_iter': 600000,
 }
 
-# TODO: change default values (copied from Sshort)
-# Add learning rate disruptions to fine-tune on Sintel and Kitti from PWC-Net+ (from paper:
+# learning rate disruptions to fine-tune on Sintel and Kitti from PWC-Net+ (from paper:
 #  Models matter, so does training: an empirical study of CNNs for optical flow estimation"
 # The authors recently uploaded the caffe training protocols on:
 # github.com/NVlabs/PWC-Net/tree/master/Caffe/model/PWC-Net_plus (although only for KITTI and Sintel it seems...)

--- a/src/training_schedules.py
+++ b/src/training_schedules.py
@@ -1,14 +1,13 @@
-# TODO: also add proper fine-tuning for each dataset (following PWC-Net+ findings!)
 # thanks to: https://arxiv.org/pdf/1809.05571.pdf (the code has not been updated yet but the paper is out!)
 # schedules reproduced (aside from long which was already provided) from og repo at: github.com/lmb-freiburg/flownet2
 # Must navigate to models and download models to get the text files (*proto.txt): one for 'long', 'fine' and 'short'
 LONG_SCHEDULE_TMP = {
-    'step_values': [134876, 334876, 534876, 734876],
-    'learning_rates': [0.0001, 0.00005, 0.000025, 0.0000125, 0.00000625],
+    'step_values': [132799, 332799],
+    'learning_rates': [0.000025, 0.0000125, 0.00000625],
     'momentum': 0.9,
     'momentum2': 0.999,
     'weight_decay': 0.0004,
-    'max_iter': 1065124,
+    'max_iter': 532799,
 }
 LONG_SCHEDULE = {
     'step_values': [400000, 600000, 800000, 1000000],


### PR DESCRIPTION
Merge changes to fix resuming from previous checkpoint. Basically:
* We fixed the global step not being properly resumed (training restarted at global_step = 0)
* This implied that the training schedule used the initial learning rate, weight decay, etc. instead of the ones of the resumed step.

This change however, implies that the training schedules that will be applied sequentially have to adapt the iterations at which a new step is taking. So, for instance, if we are fine-tuning with flyingthings3d, we start the count at 1.2M iterations and proceed (then step at 1.4M instead of simply writing 200K, etc.). Nevertheless the maximum number of iterations remains constant at 500K in this case.