### PR TITLE
Fix exploding loss when resuming training from checkpoint

### DIFF
--- a/src/flownet_s_interp/flownet_s_interp.py
+++ b/src/flownet_s_interp/flownet_s_interp.py
@@ -40,7 +40,7 @@ class FlowNetS_interp(Net):
                                 activation_fn=LeakyReLU,
                                 # We will do our own padding to match the original Caffe code
                                 padding='VALID'):
-
+                # TODO: for adaptive optimizers: L2reg != weight_decay, change the name to reflect that
                 weights_regularizer = slim.l2_regularizer(training_schedule['weight_decay'])
                 with slim.arg_scope([slim.conv2d], weights_regularizer=weights_regularizer):
                     with slim.arg_scope([slim.conv2d], stride=2):

--- a/src/net.py
+++ b/src/net.py
@@ -666,16 +666,17 @@ class Net(object):
                 step_number = int(checkpoint_path.split('-')[-1])
                 checkpoint_global_step_tensor = tf.Variable(step_number, trainable=False, name='global_step',
                                                             dtype='int64')
-                path_to_checkpoint_fld = os.path.dirname(checkpoint_path)
+                # path_to_checkpoint_fld = os.path.dirname(checkpoint_path)
                 if log_verbosity > 2:
-                    print("Path to checkpoint folder is: '{}'".format(path_to_checkpoint_fld))
-                ckpt = tf.train.get_checkpoint_state(path_to_checkpoint_fld)
+                    print("Path to checkpoint folder is: '{}'".format(os.path.dirname(checkpoints + '/checkpoint')))
+                ckpt = tf.train.get_checkpoint_state(os.path.dirname(checkpoints + '/checkpoint'))
 
                 if log_verbosity > 2:
                     print("Is ckpt None: {0}".format(ckpt is None))
                 saver = tf.train.Saver(
                     max_to_keep=3, keep_checkpoint_every_n_hours=2, var_list=optimistic_restore_vars(
-                        ckpt.model_checkpoint_path) if checkpoint_path else None)
+                        ckpt.model_checkpoint_path) if checkpoints else None)
+
 
             else:
                 raise ValueError("checkpoint should be a single path (string) or a dictionary for stacked networks")

--- a/src/net.py
+++ b/src/net.py
@@ -61,12 +61,16 @@ def optimistic_restore_vars(model_checkpoint_path):
     print("model_checkpoint_path is {}".format(model_checkpoint_path))
     reader = tf.train.NewCheckpointReader(model_checkpoint_path)
     saved_shapes = reader.get_variable_to_shape_map()
-    print("len(saved_shapes.keys()): {}".format(len(saved_shapes.keys())))
+    print("Printing all vars in checkpoint BEFORE filtering, total={}".format(len(saved_shapes.keys())))
+    for shape in saved_shapes:
+        print(shape)
+
     var_names = sorted([(var.name, var.name.split(':')[0]) for var in tf.global_variables()
                         if var.name.split(':')[0] in saved_shapes])
-    print("len(var_names): {}".format(len(var_names)))
+    print("Printing all vars in checkpoint AFTER filtering, total={}".format(len(var_names)))
+
     restore_vars = []
-    name2var = dict(zip(map(lambda x: x.name.split(':')[0], tf.global_variables()), tf.global_variables()))
+    name2var = dict(zip(map(lambda x:x.name.split(':')[0], tf.global_variables()), tf.global_variables()))
     with tf.variable_scope('', reuse=True):
         for var_name, saved_var_name in var_names:
             curr_var = name2var[saved_var_name]
@@ -649,15 +653,14 @@ class Net(object):
                 # TODO: adapt resuming from saver to stacked architectures if it works for one standalone
                 saver = None
             elif isinstance(checkpoints, str):
-                print("checkpoints is str, {}".format(checkpoints))
                 checkpoint_path = checkpoints
-                variables_to_restore = slim.get_model_variables()
-                if log_verbosity > 1:
-                    print("Restoring the following variables from checkpoint (SLIM), total: {}".format(
-                        len(variables_to_restore)))
-                    for var in variables_to_restore:
-                        print("SLIM: {}".format(var))
-                    print("Finished printing list of restored variables")
+                # variables_to_restore = slim.get_model_variables()
+                # if log_verbosity > 1:
+                #     print("Restoring the following variables from checkpoint (SLIM), total: {}".format(
+                #         len(variables_to_restore)))
+                #     for var in variables_to_restore:
+                #         print("SLIM: {}".format(var))
+                #     print("Finished printing list of restored variables")
                 #
                 # init_assign_op, init_feed_dict = slim.assign_from_checkpoint(
                 #     checkpoint_path, variables_to_restore)

--- a/src/net.py
+++ b/src/net.py
@@ -676,9 +676,9 @@ class Net(object):
                 #                                             dtype='int64')
 
                 # likely fix to not proper resuming (huge loss)
-                step_number = int(checkpoint_path.split('-')[-1])
-                checkpoint_global_step_tensor = tf.Variable(step_number, trainable=False, name='global_step',
-                                                            dtype='int64')
+                # step_number = int(checkpoint_path.split('-')[-1])
+                # checkpoint_global_step_tensor = tf.Variable(step_number, trainable=False, name='global_step',
+                #                                             dtype='int64')
                 # path_to_checkpoint_fld = os.path.dirname(checkpoint_path)
                 if log_verbosity > 1:
                     print("Path to checkpoint folder is: '{}'".format(os.path.dirname(checkpoint_path)))
@@ -687,6 +687,9 @@ class Net(object):
                 if log_verbosity > 1:
                     print("Is ckpt None: {0}".format(ckpt is None))
                 vars2restore = optimistic_restore_vars(ckpt.model_checkpoint_path)
+                step_number = int(checkpoint_path.split('-')[-1])
+                checkpoint_global_step_tensor = tf.Variable(step_number, trainable=False, name='global_step',
+                                                            dtype='int64')
                 if log_verbosity > 1:
                     print("Listing variables that will be restored(optimistic_restore_vars), total: {}:".format(
                         len(vars2restore)))

--- a/src/net.py
+++ b/src/net.py
@@ -81,14 +81,10 @@ def optimistic_restore_vars(model_checkpoint_path, filter_by_scope=False):
 def keep_scope_restore_vars(model_checkpoint_path):
     print("model_checkpoint_path is {}".format(model_checkpoint_path))
     reader = tf.train.NewCheckpointReader(model_checkpoint_path)
-    var_names = reader.get_variable_to_shape_map().keys()
-    restore_dict = {}
-    for v in var_names:
-        restore_dict[v] = reader.get_tensor(v)
-
-    print("Dictionary of variables has elements:")
-    for elem in restore_dict:
-        print(elem)
+    var_to_shape_map = reader.get_variable_to_shape_map()
+    restore_dict = dict()
+    for key in sorted(var_to_shape_map):
+        print("({}, {})".format(reader.get_tensor(key), key))
     return restore_dict
 
 

--- a/src/net.py
+++ b/src/net.py
@@ -855,7 +855,7 @@ class Net(object):
                 saver = None
             elif isinstance(checkpoints, str):
                 checkpoint_path = checkpoints
-                variables_to_restore = slim.get_model_variables()
+                variables_to_restore = slim.get_variables_to_restore()
                 if log_verbosity > 1:
                     print("Restoring the following variables from checkpoint (SLIM), total: {}".format(
                         len(variables_to_restore)))
@@ -891,6 +891,8 @@ class Net(object):
                 saver = tf.train.Saver(max_to_keep=3, keep_checkpoint_every_n_hours=2,
                                        var_list=vars2restore if checkpoint_path else None)
                 local_init_op = tf.global_variables_initializer()  # may be needed to successfully resume
+                ckpt_basepath = os.path.join('-'.join(checkpoint_path.split('-')[:-1]))
+                init_fn = tf.contrib.framework.assign_from_checkpoint_fn(ckpt_basepath, vars2restore)
 
             else:
                 raise ValueError("checkpoint should be a single path (string) or a dictionary for stacked networks")
@@ -954,6 +956,7 @@ class Net(object):
                     # train_step_fn=train_step_fn,
                     saver=saver,
                     local_init_op=local_init_op,
+                    init_fn=init_fn,
                 )
             else:
                 final_loss = slim.learning.train(

--- a/src/net.py
+++ b/src/net.py
@@ -891,8 +891,7 @@ class Net(object):
                 saver = tf.train.Saver(max_to_keep=3, keep_checkpoint_every_n_hours=2,
                                        var_list=vars2restore if checkpoint_path else None)
                 local_init_op = tf.global_variables_initializer()  # may be needed to successfully resume
-                ckpt_basepath = os.path.join('-'.join(checkpoint_path.split('-')[:-1]))
-                init_fn = tf.contrib.framework.assign_from_checkpoint_fn(ckpt_basepath, vars2restore)
+                init_fn = tf.contrib.framework.assign_from_checkpoint_fn(checkpoint_path, vars2restore)
 
             else:
                 raise ValueError("checkpoint should be a single path (string) or a dictionary for stacked networks")

--- a/src/net.py
+++ b/src/net.py
@@ -855,13 +855,13 @@ class Net(object):
                 saver = None
             elif isinstance(checkpoints, str):
                 checkpoint_path = checkpoints
-                # variables_to_restore = slim.get_model_variables()
-                # if log_verbosity > 1:
-                #     print("Restoring the following variables from checkpoint (SLIM), total: {}".format(
-                #         len(variables_to_restore)))
-                #     for var in variables_to_restore:
-                #         print("SLIM: {}".format(var))
-                #     print("Finished printing list of restored variables")
+                variables_to_restore = slim.get_model_variables()
+                if log_verbosity > 1:
+                    print("Restoring the following variables from checkpoint (SLIM), total: {}".format(
+                        len(variables_to_restore)))
+                    for var in variables_to_restore:
+                        print("SLIM: {}".format(var))
+                    print("Finished printing list of restored variables")
                 #
                 # init_assign_op, init_feed_dict = slim.assign_from_checkpoint(
                 #     checkpoint_path, variables_to_restore)

--- a/src/net.py
+++ b/src/net.py
@@ -58,10 +58,13 @@ class Mode(Enum):
 #       * Then this tf.Saver() can be passed to tf.slim.learning.train() and hopefully we can resume training:
 #           * with a loss approximately of the same value of that yield before pausing/stopping training
 def optimistic_restore_vars(model_checkpoint_path):
+    print("model_checkpoint_path is {}".format(model_checkpoint_path))
     reader = tf.train.NewCheckpointReader(model_checkpoint_path)
     saved_shapes = reader.get_variable_to_shape_map()
+    print("len(saved_shapes.keys()): {}".format(len(saved_shapes.keys())))
     var_names = sorted([(var.name, var.name.split(':')[0]) for var in tf.global_variables()
                         if var.name.split(':')[0] in saved_shapes])
+    print("len(var_names): {}".format(len(var_names)))
     restore_vars = []
     name2var = dict(zip(map(lambda x: x.name.split(':')[0], tf.global_variables()), tf.global_variables()))
     with tf.variable_scope('', reuse=True):
@@ -678,7 +681,7 @@ class Net(object):
                     print("Listing variables that will be restored:")
                     for var in vars2restore:
                         print(var)
-                        
+
                 saver = tf.train.Saver(
                     max_to_keep=3, keep_checkpoint_every_n_hours=2, var_list=vars2restore if checkpoint_path else None)
 

--- a/src/net.py
+++ b/src/net.py
@@ -649,13 +649,14 @@ class Net(object):
                 # TODO: adapt resuming from saver to stacked architectures if it works for one standalone
                 saver = None
             elif isinstance(checkpoints, str):
+                print("checkpoints is str, {}".format(checkpoints))
                 checkpoint_path = checkpoints
-                # variables_to_restore = slim.get_model_variables()
-                # if log_verbosity > 1:
-                #     print("Restoring the following variables from checkpoint:")
-                #     for var in variables_to_restore:
-                #         print(var)
-                #     print("Finished printing list of restored variables")
+                variables_to_restore = slim.get_model_variables()
+                if log_verbosity > 1:
+                    print("Restoring the following variables from checkpoint (SLIM):")
+                    for var in variables_to_restore:
+                        print(var)
+                    print("Finished printing list of restored variables")
                 #
                 # init_assign_op, init_feed_dict = slim.assign_from_checkpoint(
                 #     checkpoint_path, variables_to_restore)
@@ -678,7 +679,8 @@ class Net(object):
                     print("Is ckpt None: {0}".format(ckpt is None))
                 vars2restore = optimistic_restore_vars(ckpt.model_checkpoint_path)
                 if log_verbosity > 1:
-                    print("Listing variables that will be restored:")
+                    print("Listing variables that will be restored(optimistic_restore_vars), total: {}:".format(
+                        len(vars2restore)))
                     for var in vars2restore:
                         print(var)
 

--- a/src/net.py
+++ b/src/net.py
@@ -683,6 +683,7 @@ class Net(object):
                         len(vars2restore)))
                     for var in vars2restore:
                         print(var)
+                    sys.stdout.flush()
 
                 saver = tf.train.Saver(
                     max_to_keep=3, keep_checkpoint_every_n_hours=2, var_list=vars2restore if checkpoint_path else None)

--- a/src/net.py
+++ b/src/net.py
@@ -798,9 +798,7 @@ class Net(object):
             print("Prining corresponding variable fo each slot")
             train_vars = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES)
             adam_var_list = [optimizer.get_slot(var, name) for name in optimizer.get_slot_names() for var in train_vars]
-            adam_var_list.extend([
-                optimizer._beta1_power, optimizer._beta2_power
-            ])
+            print(optimizer._get_beta_accumulators())
             for var in adam_var_list:
                 print("(adam): {}".format(var))
 

--- a/src/net.py
+++ b/src/net.py
@@ -73,14 +73,13 @@ def optimistic_restore_vars(model_checkpoint_path):
 
     restore_vars = []
     name2var = dict(zip(map(lambda x: x.name.split(':')[0], tf.global_variables()), tf.global_variables()))
-    print("Restoring variables (check name)...")
+    print("Restoring variables...")
     with tf.variable_scope('', reuse=True):
         for var_name, saved_var_name in var_names:
             curr_var = name2var[saved_var_name]
             var_shape = curr_var.get_shape().as_list()
             if var_shape == saved_shapes[saved_var_name]:
                 restore_vars.append(curr_var)
-                print("restored with name: {}".format(curr_var))
     return restore_vars
 
 
@@ -826,13 +825,13 @@ class Net(object):
                 saver = None
             elif isinstance(checkpoints, str):
                 checkpoint_path = checkpoints
-                variables_to_restore = slim.get_model_variables()
-                if log_verbosity > 1:
-                    print("Restoring the following variables from checkpoint (SLIM), total: {}".format(
-                        len(variables_to_restore)))
-                    for var in variables_to_restore:
-                        print("SLIM: {}".format(var))
-                    print("Finished printing list of restored variables")
+                # variables_to_restore = slim.get_model_variables()
+                # if log_verbosity > 1:
+                #     print("Restoring the following variables from checkpoint (SLIM), total: {}".format(
+                #         len(variables_to_restore)))
+                #     for var in variables_to_restore:
+                #         print("SLIM: {}".format(var))
+                #     print("Finished printing list of restored variables")
                 #
                 # init_assign_op, init_feed_dict = slim.assign_from_checkpoint(
                 #     checkpoint_path, variables_to_restore)
@@ -843,6 +842,7 @@ class Net(object):
                 #                                             dtype='int64')
 
                 if log_verbosity > 1:
+                    print("Checkpoint path (to file) was: {}".format(checkpoint_path))
                     print("Path to checkpoint folder is: '{}'".format(os.path.dirname(checkpoint_path)))
                 ckpt = tf.train.get_checkpoint_state(os.path.dirname(checkpoint_path))
 

--- a/src/net.py
+++ b/src/net.py
@@ -798,6 +798,9 @@ class Net(object):
             print("Prining corresponding variable fo each slot")
             train_vars = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES)
             adam_var_list = [optimizer.get_slot(var, name) for name in optimizer.get_slot_names() for var in train_vars]
+            adam_var_list.extend([
+                optimizer._beta1_power, optimizer._beta2_power
+            ])
             for var in adam_var_list:
                 print("(adam): {}".format(var))
 

--- a/src/net.py
+++ b/src/net.py
@@ -668,15 +668,14 @@ class Net(object):
                                                             dtype='int64')
                 # path_to_checkpoint_fld = os.path.dirname(checkpoint_path)
                 if log_verbosity > 1:
-                    print("Path to checkpoint folder is: '{}'".format(os.path.dirname(checkpoints + '/checkpoint')))
-                ckpt = tf.train.get_checkpoint_state(os.path.dirname(checkpoints + '/checkpoint'))
+                    print("Path to checkpoint folder is: '{}'".format(os.path.dirname(checkpoint_path)))
+                ckpt = tf.train.get_checkpoint_state(os.path.dirname(checkpoint_path))
 
                 if log_verbosity > 1:
                     print("Is ckpt None: {0}".format(ckpt is None))
                 saver = tf.train.Saver(
                     max_to_keep=3, keep_checkpoint_every_n_hours=2, var_list=optimistic_restore_vars(
-                        ckpt.model_checkpoint_path) if checkpoints else None)
-
+                        ckpt.model_checkpoint_path) if checkpoint_path else None)
 
             else:
                 raise ValueError("checkpoint should be a single path (string) or a dictionary for stacked networks")

--- a/src/net.py
+++ b/src/net.py
@@ -64,6 +64,9 @@ def optimistic_restore_vars(model_checkpoint_path):
     print("Printing all vars in checkpoint BEFORE filtering, total={}".format(len(saved_shapes.keys())))
     for shape in saved_shapes:
         print(shape)
+    print("vars if tf.global_variables()")
+    for var in tf.global_variables():
+        print(var)
 
     var_names = sorted([(var.name, var.name.split(':')[0]) for var in tf.global_variables()
                         if var.name.split(':')[0] in saved_shapes])

--- a/src/net.py
+++ b/src/net.py
@@ -81,11 +81,22 @@ def optimistic_restore_vars(model_checkpoint_path, filter_by_scope=False):
 def keep_scope_restore_vars(model_checkpoint_path):
     print("model_checkpoint_path is {}".format(model_checkpoint_path))
     reader = tf.train.NewCheckpointReader(model_checkpoint_path)
-    var_to_shape_map = reader.get_variable_to_shape_map()
-    restore_dict = dict()
-    for key in sorted(var_to_shape_map):
-        print("({}, {})".format(reader.get_tensor(key), key))
-    return restore_dict
+    saved_shapes = reader.get_variable_to_shape_map()
+    print(saved_shapes)
+    var_names = sorted([(var.name, var.name.split(':')[0]) for var in saved_shapes])
+    # var_names = sorted([(var.name, var.name.split(':')[0]) for var in tf.global_variables()
+    #                     if var.name.split(':')[0] in saved_shapes])
+
+    # restore_vars = []
+    # name2var = dict(zip(map(lambda x: x.name.split(':')[0], tf.global_variables()), tf.global_variables()))
+    # with tf.variable_scope('', reuse=True):
+    #     for var_name, saved_var_name in var_names:
+    #         curr_var = name2var[saved_var_name]
+    #         var_shape = curr_var.get_shape().as_list()
+    #         if var_shape == saved_shapes[saved_var_name]:
+    #             restore_vars.append(curr_var)
+    #             print("restored with name: ".format(curr_var))
+    return restore_vars
 
 
 class Net(object):

--- a/src/net.py
+++ b/src/net.py
@@ -664,7 +664,12 @@ class Net(object):
 
                 # likely fix to not proper resuming (huge loss)
                 path_to_checkpoint_fld = os.path.dirname(checkpoint_path)
-                ckpt = tf.train.get_checkpoint_state(os.path.join(path_to_checkpoint_fld, 'checkpoint'))
+                if log_verbosity > 2:
+                    print("Path to checkpoint folder is: '{}'".format(path_to_checkpoint_fld))
+                ckpt = tf.train.get_checkpoint_state(path_to_checkpoint_fld)
+
+                if log_verbosity > 2:
+                    print("Is ckpt None: {0}".format(ckpt is None))
                 saver = tf.train.Saver(max_to_keep=3, keep_checkpoint_every_n_hours=2,
                                        var_list=optimistic_restore_vars(ckpt.model_checkpoint_path) if checkpoint_path
                                        else None)

--- a/src/net.py
+++ b/src/net.py
@@ -954,7 +954,7 @@ class Net(object):
                     # init_fn=InitAssignFn,
                     # train_step_fn=train_step_fn,
                     saver=saver,
-                    local_init_op=local_init_op,
+                    # local_init_op=local_init_op,
                     init_fn=init_fn,
                 )
             else:

--- a/src/net.py
+++ b/src/net.py
@@ -68,7 +68,8 @@ def optimistic_restore_vars(model_checkpoint_path):
     var_names = sorted([(var.name, var.name.split(':')[0]) for var in tf.global_variables()
                         if var.name.split(':')[0] in saved_shapes])
     print("Printing all vars in checkpoint AFTER filtering, total={}".format(len(var_names)))
-
+    for var in var_names:
+        print(var)
     restore_vars = []
     name2var = dict(zip(map(lambda x:x.name.split(':')[0], tf.global_variables()), tf.global_variables()))
     with tf.variable_scope('', reuse=True):

--- a/src/net.py
+++ b/src/net.py
@@ -673,9 +673,14 @@ class Net(object):
 
                 if log_verbosity > 1:
                     print("Is ckpt None: {0}".format(ckpt is None))
+                vars2restore = optimistic_restore_vars(ckpt.model_checkpoint_path)
+                if log_verbosity > 1:
+                    print("Listing variables that will be restored:")
+                    for var in vars2restore:
+                        print(var)
+                        
                 saver = tf.train.Saver(
-                    max_to_keep=3, keep_checkpoint_every_n_hours=2, var_list=optimistic_restore_vars(
-                        ckpt.model_checkpoint_path) if checkpoint_path else None)
+                    max_to_keep=3, keep_checkpoint_every_n_hours=2, var_list=vars2restore if checkpoint_path else None)
 
             else:
                 raise ValueError("checkpoint should be a single path (string) or a dictionary for stacked networks")

--- a/src/net.py
+++ b/src/net.py
@@ -81,22 +81,15 @@ def optimistic_restore_vars(model_checkpoint_path, filter_by_scope=False):
 def keep_scope_restore_vars(model_checkpoint_path):
     print("model_checkpoint_path is {}".format(model_checkpoint_path))
     reader = tf.train.NewCheckpointReader(model_checkpoint_path)
-    saved_shapes = reader.get_variable_to_shape_map()
-    # for shape in saved_shapes:
-    #     print(shape)
-    # var_names = sorted([(var.name, var.name.split(':')[0]) for var in tf.global_variables()
-    #                     if var.name.split(':')[0] in saved_shapes])
-    #
-    # restore_vars = []
-    # name2var = dict(zip(map(lambda x: x.name.split(':')[0], tf.global_variables()), tf.global_variables()))
-    # with tf.variable_scope('', reuse=True):
-    #     for var_name, saved_var_name in var_names:
-    #         curr_var = name2var[saved_var_name]
-    #         var_shape = curr_var.get_shape().as_list()
-    #         if var_shape == saved_shapes[saved_var_name]:
-    #             restore_vars.append(curr_var)
-    restore_vars = saved_shapes
-    return restore_vars
+    var_names = reader.get_variable_to_shape_map().keys()
+    restore_dict = {}
+    for v in var_names:
+        restore_dict[v] = reader.get_tensor(v)
+
+    print("Dictionary of variables has elements:")
+    for elem in restore_dict:
+        print(elem)
+    return restore_dict
 
 
 class Net(object):

--- a/src/net.py
+++ b/src/net.py
@@ -71,13 +71,14 @@ def optimistic_restore_vars(model_checkpoint_path):
     for var in var_names:
         print(var)
     restore_vars = []
-    name2var = dict(zip(map(lambda x:x.name.split(':')[0], tf.global_variables()), tf.global_variables()))
+    name2var = dict(zip(map(lambda x: x.name.split(':')[0], tf.global_variables()), tf.global_variables()))
     with tf.variable_scope('', reuse=True):
         for var_name, saved_var_name in var_names:
             curr_var = name2var[saved_var_name]
             var_shape = curr_var.get_shape().as_list()
             if var_shape == saved_shapes[saved_var_name]:
                 restore_vars.append(curr_var)
+                print("restored with name: ".format(curr_var))
     return restore_vars
 
 

--- a/src/net.py
+++ b/src/net.py
@@ -653,9 +653,10 @@ class Net(object):
                 checkpoint_path = checkpoints
                 variables_to_restore = slim.get_model_variables()
                 if log_verbosity > 1:
-                    print("Restoring the following variables from checkpoint (SLIM):")
+                    print("Restoring the following variables from checkpoint (SLIM), total: {}".format(
+                        len(variables_to_restore)))
                     for var in variables_to_restore:
-                        print(var)
+                        print("SLIM: {}".format(var))
                     print("Finished printing list of restored variables")
                 #
                 # init_assign_op, init_feed_dict = slim.assign_from_checkpoint(
@@ -682,7 +683,7 @@ class Net(object):
                     print("Listing variables that will be restored(optimistic_restore_vars), total: {}:".format(
                         len(vars2restore)))
                     for var in vars2restore:
-                        print(var)
+                        print("(optimistic_restore_vars): {}".format(var))
                     sys.stdout.flush()
 
                 saver = tf.train.Saver(

--- a/src/net.py
+++ b/src/net.py
@@ -80,7 +80,7 @@ def optimistic_restore_vars(model_checkpoint_path):
             var_shape = curr_var.get_shape().as_list()
             if var_shape == saved_shapes[saved_var_name]:
                 restore_vars.append(curr_var)
-                print("restored with name: ".format(curr_var))
+                print("restored with name: {}".format(curr_var))
     return restore_vars
 
 
@@ -850,9 +850,6 @@ class Net(object):
                     print("Is ckpt None: {0}".format(ckpt is None))
                 vars2restore = optimistic_restore_vars(ckpt.model_checkpoint_path)
                 # vars2restore = keep_scope_restore_vars(ckpt.model_checkpoint_path)
-                step_number = int(checkpoint_path.split('-')[-1])
-                checkpoint_global_step_tensor = tf.Variable(step_number, trainable=False, name='global_step',
-                                                            dtype='int64')
                 if log_verbosity > 1:
                     print("Listing variables that will be restored(optimistic_restore_vars), total: {}:".format(
                         len(vars2restore)))

--- a/src/net.py
+++ b/src/net.py
@@ -667,11 +667,11 @@ class Net(object):
                 checkpoint_global_step_tensor = tf.Variable(step_number, trainable=False, name='global_step',
                                                             dtype='int64')
                 # path_to_checkpoint_fld = os.path.dirname(checkpoint_path)
-                if log_verbosity > 2:
+                if log_verbosity > 1:
                     print("Path to checkpoint folder is: '{}'".format(os.path.dirname(checkpoints + '/checkpoint')))
                 ckpt = tf.train.get_checkpoint_state(os.path.dirname(checkpoints + '/checkpoint'))
 
-                if log_verbosity > 2:
+                if log_verbosity > 1:
                     print("Is ckpt None: {0}".format(ckpt is None))
                 saver = tf.train.Saver(
                     max_to_keep=3, keep_checkpoint_every_n_hours=2, var_list=optimistic_restore_vars(

--- a/src/net.py
+++ b/src/net.py
@@ -663,6 +663,9 @@ class Net(object):
                 #                                             dtype='int64')
 
                 # likely fix to not proper resuming (huge loss)
+                step_number = int(checkpoint_path.split('-')[-1])
+                checkpoint_global_step_tensor = tf.Variable(step_number, trainable=False, name='global_step',
+                                                            dtype='int64')
                 path_to_checkpoint_fld = os.path.dirname(checkpoint_path)
                 if log_verbosity > 2:
                     print("Path to checkpoint folder is: '{}'".format(path_to_checkpoint_fld))
@@ -670,15 +673,11 @@ class Net(object):
 
                 if log_verbosity > 2:
                     print("Is ckpt None: {0}".format(ckpt is None))
-                saver = tf.train.Saver(max_to_keep=3, keep_checkpoint_every_n_hours=2,
-                                       var_list=optimistic_restore_vars(ckpt.model_checkpoint_path) if checkpoint_path
-                                       else None)
-                step_number = int(checkpoint_path.split('-')[-1])
-                checkpoint_global_step_tensor = tf.Variable(step_number, trainable=False, name='global_step',
-                                                            dtype='int64')
+                saver = tf.train.Saver(
+                    max_to_keep=3, keep_checkpoint_every_n_hours=2, var_list=optimistic_restore_vars(
+                        ckpt.model_checkpoint_path) if checkpoint_path else None)
+
             else:
-                saver = None
-                checkpoint_global_step_tensor = None
                 raise ValueError("checkpoint should be a single path (string) or a dictionary for stacked networks")
         else:
             saver = None

--- a/src/net.py
+++ b/src/net.py
@@ -890,6 +890,7 @@ class Net(object):
                 # Initialise saver with custom settings and list of variables to restore (resumed training)
                 saver = tf.train.Saver(max_to_keep=3, keep_checkpoint_every_n_hours=2,
                                        var_list=vars2restore if checkpoint_path else None)
+                local_init_op = tf.global_variables_initializer()  # may be needed to successfully resume
 
             else:
                 raise ValueError("checkpoint should be a single path (string) or a dictionary for stacked networks")
@@ -952,6 +953,7 @@ class Net(object):
                     # init_fn=InitAssignFn,
                     # train_step_fn=train_step_fn,
                     saver=saver,
+                    local_init_op=local_init_op,
                 )
             else:
                 final_loss = slim.learning.train(


### PR DESCRIPTION
Fixed the loss exploding when we resumed training from an existing checkpoint.
Basically, the three things we needed to do (using the SLIM high-level API with `slim.learning.train`), are described [in this reply to a similar issue.](https://github.com/tensorflow/tensorflow/issues/13342#issuecomment-500800855)

We also added some flags to define more parameters of the Cyclic Learning Rate (CLR) policy and learning rate range test.