### PR TITLE
Basic functionality to dynamically sample gt_flow while training to see different matching densities

### DIFF
--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -332,7 +332,7 @@ def set_range_to_zero(matches, width, offset_h, offset_w, crop_h, crop_w):
     print("range_rows.shape: {}\nrange_cols.shape: {}".format(range_rows.shape, range_cols.shape))
     # Get absolute indices as rows * width + cols
     indices = tf.add(tf.multiply(range_rows, width), range_cols)
-    zeros = tf.Variable(tf.zeros(tf.shape(indices)), trainable=False)
+    zeros = tf.zeros(tf.shape(indices))
     print("matches.shape: {}\nindices.shape: {}\nzeros.shape: {}".format(matches.shape, indices.shape, zeros.shape))
     print("type(matches): {}\ntype(indices): {}\ntype(zeros): {}".format(type(matches), type(indices), type(zeros)))
     matches = tf.scatter_update(matches, indices, zeros)

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -210,7 +210,7 @@ def sample_gt_flow_to_sparse(gt_flow, target_density=75, target_distribution='un
             np.uint8)
         random_mask = sampling_mask == 255
         random_mask_rep = np.repeat(random_mask[:, :, :, np.newaxis], 2, axis=-1)
-        tf.print(random_mask_rep.shape)
+        print(random_mask_rep.shape)
         #tf.print(sampling_mask)
     #       sampling_mask_logical = sampling_mask == 1
     #       pixel_idxs = np.where(sampling_mask == 1)
@@ -222,8 +222,8 @@ def sample_gt_flow_to_sparse(gt_flow, target_density=75, target_distribution='un
     #     pixel_idxs = tf.convert_to_tensor(pixel_idxs, name='pixel_idxs')
     #     sampling_mask_logical = tf.convert_to_tensor(sampling_mask_logical, name='sampling_mask_logical')
     # gt_flow_pixel_idxs = tf.cast(tf.boolean_mask(gt_flow, sampling_mask_logical), dtype=tf.float32)
-    tf.print(sparse_flow.shape)
-    tf.print(gt_flow.shape)
+    print(sparse_flow.shape)
+    print(gt_flow.shape)
     sparse_flow[random_mask_rep] = gt_flow[random_mask_rep]
     sparse_flow = tf.convert_to_tensor(sparse_flow, name='sparse_flow')
     # sparse_flow = tf.scatter_update(sparse_flow, pixel_idxs, gt_flow_pixel_idxs)

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -330,7 +330,7 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
     num_samples_w = tf.cast(tf.round(tf.sqrt(tf.multiply(num_samples, aspect_ratio))),
                             dtype=tf.int32)
     # num_samples_w = int(np.round(np.sqrt(num_samples * aspect_ratio)))
-    num_samples_h = tf.cast(tf.round(tf.sqrt(tf.divide(num_samples_w, aspect_ratio))),
+    num_samples_h = tf.cast(tf.round(tf.sqrt(tf.divide(tf.cast(num_samples_w, dtype=tf.float32), aspect_ratio))),
                             dtype=tf.int32)
     # num_samples_h = int(np.round(num_samples_w / aspect_ratio))
 

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -212,7 +212,7 @@ def sample_gt_flow_to_sparse(gt_flow, target_density=75, target_distribution='un
     if target_distribution.lower() == 'uniform':
         sampling_mask = np.random.choice([0, 255], size=gt_flow.shape[:-1], p=[1 - p_fill, p_fill]).astype(
             np.int32)
-        matches = tf.cast(tf.expand_dims(255 * sampling_mask, 0), dtype=tf.uint8)  # convert to (h, w, 1)
+        matches = tf.cast(tf.expand_dims(255 * sampling_mask, 0), dtype=tf.float32)  # convert to (h, w, 1)
         sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
         sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
         sampling_mask_flatten = np.where(sampling_mask_flatten == 255)

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -282,7 +282,7 @@ def sample_sparse_invalid_like(gt_flow, target_density=75, height=384, width=512
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
-    sampling_mask_flatten = tf.where_v2(tf.equal(sampling_mask_flatten, tf.constant(255)))
+    sampling_mask_flatten = tf.compat.v1.where_v2(tf.equal(sampling_mask_flatten, tf.constant(255)))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
@@ -315,7 +315,7 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
-    sampling_mask_flatten = tf.where_v2(tf.equal(sampling_mask_flatten, tf.constant(255)))
+    sampling_mask_flatten = tf.compat.v1.where_v2(tf.equal(sampling_mask_flatten, tf.constant(255)))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
@@ -413,7 +413,7 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
-    sampling_mask_flatten = tf.where_v2(tf.equal(sampling_mask_flatten, tf.constant(255)))
+    sampling_mask_flatten = tf.compat.v1.where_v2(tf.equal(sampling_mask_flatten, tf.constant(255)))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -200,6 +200,8 @@ def flow_resize(flow, out_size, is_scale=True, method=0):
 # Functions to sample ground truth flow with different density and probability distribution
 def sample_gt_flow_to_sparse(gt_flow, target_density=75, target_distribution='uniform'):
     """
+    Samples the provided gt flow with the target density and distribution. It also returns the updated matches mask
+    which has 1s where the samples lay and 0 elsewhere.
     :param gt_flow: tensor containing ground truth optical flow (before batching ==> shape: (h, w, 2) )
     :param target_density:
     :param target_distribution:
@@ -208,15 +210,16 @@ def sample_gt_flow_to_sparse(gt_flow, target_density=75, target_distribution='un
     sparse_flow = tf.Variable(tf.zeros(gt_flow.shape, dtype=tf.float32), trainable=False)
     p_fill = target_density / 100  # target_density expressed in %
     if target_distribution.lower() == 'uniform':
-        sampling_mask = np.random.choice([0, 1], size=gt_flow.shape[:-1], p=[1 - p_fill, p_fill]).astype(
+        sampling_mask = np.random.choice([0, 255], size=gt_flow.shape[:-1], p=[1 - p_fill, p_fill]).astype(
             np.int32)
+        matches = tf.cast(tf.expand_dims(255 * sampling_mask, 0), dtype=tf.uint8)  # convert to (h, w, 1)
         sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
         sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
-        sampling_mask_flatten = np.where(sampling_mask_flatten == 1)
+        sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
     sparse_flow = tf.Variable(tf.reshape(sparse_flow, [-1]), trainable=False)
     sparse_flow = tf.scatter_update(sparse_flow, sampling_mask_flatten[0], gt_flow_sampling_mask)
     sparse_flow = tf.reshape(sparse_flow, gt_flow.shape)
 
-    return sparse_flow, gt_flow
+    return sparse_flow, matches

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -287,19 +287,20 @@ def sample_sparse_grid_like(gt_flow, target_density=75):
     :return:
     """
     sparse_flow = tf.Variable(tf.zeros(gt_flow.shape, dtype=tf.float32), trainable=False)
-    num_samples = (target_density / 100) * np.prod(gt_flow.shape[:-1])
-    aspect_ratio = gt_flow.shape[1] / gt_flow.shape[0]
+    height, width, n_ch = gt_flow.get_shape().as_list()
+    num_samples = (target_density / 100) * height * width
+    aspect_ratio = gt_flow.shape[1] / height
     # Compute as in invalid_like for a random box to know the number of samples in horizontal and vertical
     num_samples_w = int(np.round(np.sqrt(num_samples * aspect_ratio)))
     num_samples_h = int(np.round(num_samples_w / aspect_ratio))
 
     # Check crop dimensions are plausible, otherwise crop them to fit (this alters the density we were sampling at)
-    if num_samples_h > gt_flow.shape[0] or num_samples_w > gt_flow.shape[1]:
-        num_samples_h = gt_flow.shape[0] if num_samples_h > gt_flow.shape[0] else num_samples_h
-        num_samples_w = gt_flow.shape[1] if num_samples_w > gt_flow.shape[1] else num_samples_w
+    if num_samples_h > height or num_samples_w > width:
+        num_samples_h = height if num_samples_h > height else num_samples_h
+        num_samples_w = width if num_samples_w > width else num_samples_w
 
-    sample_points_h = np.linspace(0, gt_flow.shape[0] - 1, num_samples_h, dtype=np.int32)
-    sample_points_w = np.linspace(0, gt_flow.shape[1] - 1, num_samples_w, dtype=np.int32)
+    sample_points_h = np.linspace(0, height - 1, num_samples_h, dtype=np.int32)
+    sample_points_w = np.linspace(0, width - 1, num_samples_w, dtype=np.int32)
     # Create meshgrid of all combinations (i.e.: coordinates to sample at)
     matches = np.zeros(gt_flow.shape[:-1], dtype=np.uint8)
     xx, yy = np.meshgrid(sample_points_w, sample_points_h)

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -264,7 +264,7 @@ def sample_sparse_invalid_like(gt_flow, target_density=75, height=384, width=512
     :return:
     """
     # Important: matches is already normalised to [0, 1], only use those values
-    sparse_flow = tf.Variable(tf.zeros(gt_flow.shape, dtype=tf.float32), trainable=False)
+    # sparse_flow = tf.Variable(tf.zeros(gt_flow.shape, dtype=tf.float32), trainable=False)
     rand_offset_h, rand_offset_w, crop_h, crop_w = get_random_offset_and_crop((height, width), target_density)
 
     # Define matches as 0 inside the random bbox, 1s elsewhere
@@ -287,7 +287,9 @@ def sample_sparse_invalid_like(gt_flow, target_density=75, height=384, width=512
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 1)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
-    sparse_flow = tf.Variable(tf.reshape(sparse_flow, [-1]), trainable=False)
+    zeros = lambda: tf.zeros(tf.reduce_prod(gt_flow.shape), dtype=tf.float32)
+    sparse_flow = tf.Variable(initial_value=zeros, dtype=tf.float32, trainable=False)
+    # sparse_flow = tf.Variable(tf.reshape(sparse_flow, [-1]), trainable=False)
     sparse_flow = tf.scatter_update(sparse_flow, sampling_mask_flatten[0], gt_flow_sampling_mask)
     sparse_flow = tf.reshape(sparse_flow, gt_flow.shape)
 
@@ -374,7 +376,7 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
     :return:
     """
     # Important: matches is already normalised to [0, 1]
-    sparse_flow = tf.Variable(tf.zeros(gt_flow.shape, dtype=tf.float32), trainable=False)
+    # sparse_flow = tf.Variable(tf.zeros(gt_flow.shape, dtype=tf.float32), trainable=False)
     matches = tf.zeros((height, width, 1), dtype=tf.float32)
     num_samples = tf.multiply(tf.multiply(tf.divide(target_density, 100.0), height), width)
     # num_samples = (target_density / 100) * height * width
@@ -437,7 +439,9 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 1)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
-    sparse_flow = tf.Variable(tf.reshape(sparse_flow, [-1]), trainable=False)
+    zeros = lambda: tf.zeros(tf.reduce_prod(gt_flow.shape), dtype=tf.float32)
+    sparse_flow = tf.Variable(initial_value=zeros, dtype=tf.float32, trainable=False)
+    # sparse_flow = tf.Variable(tf.reshape(sparse_flow, [-1]), trainable=False)
     sparse_flow = tf.scatter_update(sparse_flow, sampling_mask_flatten[0], gt_flow_sampling_mask)
     sparse_flow = tf.reshape(sparse_flow, gt_flow.shape)
 

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -313,17 +313,20 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     #     np.int32)  # sampling_mask.shape: (h, w)
     matches = tf.cast(tf.expand_dims(sampling_mask, -1), dtype=tf.float32)  # convert to (h, w, 1)
     sampling_mask = sampling_mask[:, :, tf.newaxis]
+    print("before tf.tile: sampling_mask.shape: {}".format(sampling_mask.shape))
     sampling_mask_rep = tf.tile(sampling_mask, [1, 1, 2])
+    print("after tf.tile: sampling_mask_rep.shape: {}".format(sampling_mask_rep.shape))
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
     sampling_mask_flatten_where = tf.where(tf.equal(sampling_mask_flatten, tf.cast(1, dtype=sampling_mask_flatten.dtype)))
     sampling_mask_flatten_where = tf.reshape(sampling_mask_flatten_where, [-1])
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 1)
-    gt_flow_boolean_mask = lambda: tf.boolean_mask(gt_flow, sampling_mask_rep)
-    gt_flow_sampling_mask = tf.Variable(initial_value=gt_flow_boolean_mask, dtype=tf.float32, validate_shape=False,
-                                        trainable=False)
-    sparse_flow = tf.reshape(sparse_flow, [-1])
+    gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
+    # gt_flow_boolean_mask = lambda: tf.boolean_mask(gt_flow, sampling_mask_rep)
+    # gt_flow_sampling_mask = tf.Variable(initial_value=gt_flow_boolean_mask, dtype=tf.float32, validate_shape=False,
+    #                                     trainable=False)
+    sparse_flow = tf.Variable(tf.reshape(sparse_flow, [-1]), trainable=False)
     print("sparse_uniform")
     print("sparse_flow.shape: {}\nsampling_mask_flatten_where.shape: {}\ngt_flow_sampling_mask.shape: {}".format(
         sparse_flow.shape, sampling_mask_flatten_where.shape, gt_flow_sampling_mask.shape))

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -211,7 +211,6 @@ def sample_gt_flow_to_sparse(gt_flow, target_density=75, target_distribution='un
         sampling_mask = np.random.choice([0, 255], size=gt_flow.shape[:-1], p=[1 - p_fill, p_fill]).astype(
             np.uint8)
         random_mask = sampling_mask == 255
-        print(random_mask.shape)
         random_mask_rep = np.repeat(random_mask[:, :, np.newaxis], 2, axis=-1)
         print(random_mask_rep.shape)
         #tf.print(sampling_mask)
@@ -227,6 +226,8 @@ def sample_gt_flow_to_sparse(gt_flow, target_density=75, target_distribution='un
     # gt_flow_pixel_idxs = tf.cast(tf.boolean_mask(gt_flow, sampling_mask_logical), dtype=tf.float32)
     print(sparse_flow.shape)
     print(gt_flow.shape)
+    print(gt_flow[random_mask_rep].shape)
+    print(sparse_flow[random_mask_rep].shape)
     sparse_flow[random_mask_rep] = gt_flow[random_mask_rep]
     sparse_flow = tf.convert_to_tensor(sparse_flow, name='sparse_flow')
     # sparse_flow = tf.scatter_update(sparse_flow, pixel_idxs, gt_flow_pixel_idxs)

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -282,7 +282,7 @@ def sample_sparse_invalid_like(gt_flow, target_density=75, height=384, width=512
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
-    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.cast(255, dtype=tf.float32)))
+    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.cast(255, dtype=sampling_mask_flatten.dtype)))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
@@ -315,7 +315,7 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
-    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.cast(255, dtype=tf.float32)))
+    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.cast(255, dtype=sampling_mask_flatten.dtype)))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
@@ -414,7 +414,7 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
-    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.cast(255, dtype=tf.float32)))
+    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.cast(255, dtype=sampling_mask_flatten.dtype)))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -322,9 +322,9 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
     sparse_flow = tf.reshape(sparse_flow, [-1])
     print("sparse_flow.shape: {}\nsampling_mask_flatten[0].shape: {}\ngt_flow_sampling_mask.shape: {}".format(
-        sparse_flow.shape, sampling_mask_flatten.shape, gt_flow_sampling_mask.shape))
-    print("type(sparse_flow): {}\ntype(sampling_mask_flatten): {}\ntype(gt_flow_sampling_mask): {}".format(
-        type(sparse_flow), type(sampling_mask_flatten), type(gt_flow_sampling_mask)))
+        sparse_flow.shape, sampling_mask_flatten.shape[0], gt_flow_sampling_mask.shape))
+    print("type(sparse_flow): {}\ntype(sampling_mask_flatten[0]): {}\ntype(gt_flow_sampling_mask): {}".format(
+        type(sparse_flow), type(sampling_mask_flatten[0]), type(gt_flow_sampling_mask)))
     sparse_flow = tf.scatter_update(sparse_flow, sampling_mask_flatten, gt_flow_sampling_mask)
     sparse_flow = tf.reshape(sparse_flow, gt_flow.shape)
 

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -320,7 +320,7 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
-    sparse_flow = tf.Variable(tf.reshape(sparse_flow, [-1]), trainable=False)
+    sparse_flow = tf.reshape(sparse_flow, [-1])
     sparse_flow = tf.scatter_update(sparse_flow, sampling_mask_flatten[0], gt_flow_sampling_mask)
     sparse_flow = tf.reshape(sparse_flow, gt_flow.shape)
 

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -320,8 +320,9 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     sampling_mask_flatten_where = tf.reshape(sampling_mask_flatten_where, [-1])
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
-    gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
+    gt_flow_sampling_mask = tf.Variable(tf.boolean_mask(gt_flow, sampling_mask_rep), trainable=False)
     sparse_flow = tf.reshape(sparse_flow, [-1])
+    print("sparse_uniform")
     print("sparse_flow.shape: {}\nsampling_mask_flatten_where.shape: {}\ngt_flow_sampling_mask.shape: {}".format(
         sparse_flow.shape, sampling_mask_flatten_where.shape, gt_flow_sampling_mask.shape))
     # print("type(sparse_flow): {}\ntype(sampling_mask_flatten[0]): {}\ntype(gt_flow_sampling_mask): {}".format(

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -335,16 +335,20 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
     # num_samples_h = int(np.round(num_samples_w / aspect_ratio))
 
     # Check crop dimensions are plausible, otherwise crop them to fit (this alters the density we were sampling at)
-    num_samples_h = tf.cond(tf.greater(num_samples_h, tf.constant(height)), lambda: tf.constant(height - 1),
-                            lambda: num_samples_h)
-    num_samples_w = tf.cond(tf.greater(num_samples_w, tf.constant(width)), lambda: tf.constant(width - 1),
-                            lambda: num_samples_w)
+    num_samples_h = tf.cond(
+        tf.greater(num_samples_h, tf.constant(height)), lambda: tf.constant(height - 1, dtype=tf.int32),
+        lambda: num_samples_h)
+    num_samples_w = tf.cond(
+        tf.greater(num_samples_w, tf.constant(width)), lambda: tf.constant(width - 1, dtype=tf.int32),
+        lambda: num_samples_w)
     # if num_samples_h > height or num_samples_w > width:
     #     num_samples_h = height if num_samples_h > height else num_samples_h
     #     num_samples_w = width if num_samples_w > width else num_samples_w
-    sample_points_h = tf.linspace(0, height - 1, num_samples_h, dtype=tf.int32)
+    sample_points_h = tf.linspace(tf.constant(0, dtype=tf.int32), tf.constant(height - 1, dtype=tf.int32),
+                                  num_samples_h)
     # sample_points_h = np.linspace(0, height - 1, num_samples_h, dtype=np.int32)
-    sample_points_w = tf.linspace(0, width - 1, num_samples_w, dtype=tf.int32)
+    sample_points_w = tf.linspace(tf.constant(0, dtype=tf.int32), tf.constant(width - 1, dtype=tf.int32),
+                                  num_samples_w)
     # sample_points_w = np.linspace(0, width - 1, num_samples_w, dtype=np.int32)
     # Create meshgrid of all combinations (i.e.: coordinates to sample at)
     # matches = tf.zeros((height, width), dtype=tf.int32)

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -322,10 +322,10 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
     sparse_flow = tf.reshape(sparse_flow, [-1])
     print("sparse_flow.shape: {}\nsampling_mask_flatten[0].shape: {}\ngt_flow_sampling_mask.shape: {}".format(
-        sparse_flow.shape, sampling_mask_flatten[0].shape, gt_flow_sampling_mask.shape))
-    print("type(sparse_flow): {}\ntype(sampling_mask_flatten[0]): {}\ntype(gt_flow_sampling_mask): {}".format(
-        type(sparse_flow), type(sampling_mask_flatten[0]), type(gt_flow_sampling_mask)))
-    sparse_flow = tf.scatter_update(sparse_flow, sampling_mask_flatten[0], gt_flow_sampling_mask)
+        sparse_flow.shape, sampling_mask_flatten.shape, gt_flow_sampling_mask.shape))
+    print("type(sparse_flow): {}\ntype(sampling_mask_flatten): {}\ntype(gt_flow_sampling_mask): {}".format(
+        type(sparse_flow), type(sampling_mask_flatten), type(gt_flow_sampling_mask)))
+    sparse_flow = tf.scatter_update(sparse_flow, sampling_mask_flatten, gt_flow_sampling_mask)
     sparse_flow = tf.reshape(sparse_flow, gt_flow.shape)
 
     return matches, sparse_flow

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -303,8 +303,6 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     :param target_density:
     :return:
     """
-    zeros = lambda: tf.zeros(gt_flow.shape, dtype=tf.float32)
-    sparse_flow = tf.Variable(initial_value=zeros, dtype=tf.float32, trainable=False)
     p_fill = tf.divide(target_density, 100.0)
     # p_fill = target_density / 100  # target_density expressed in %
     samples = tf.multinomial(tf.log([[1 - p_fill, p_fill]]), height * width)  # note log-prob
@@ -318,15 +316,20 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     print("after tf.tile: sampling_mask_rep.shape: {}".format(sampling_mask_rep.shape))
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
+    print("after flatten: sampling_mask_flatten.shape: {}".format(sampling_mask_flatten.shape))
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
     sampling_mask_flatten_where = tf.where(tf.equal(sampling_mask_flatten, tf.cast(1, dtype=sampling_mask_flatten.dtype)))
+    print("after tf.where: sampling_mask_flatten_where.shape: {}".format(sampling_mask_flatten_where.shape))
     sampling_mask_flatten_where = tf.reshape(sampling_mask_flatten_where, [-1])
+    print("after flatten: sampling_mask_flatten_where.shape: {}".format(sampling_mask_flatten_where.shape))
+
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 1)
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
     # gt_flow_boolean_mask = lambda: tf.boolean_mask(gt_flow, sampling_mask_rep)
     # gt_flow_sampling_mask = tf.Variable(initial_value=gt_flow_boolean_mask, dtype=tf.float32, validate_shape=False,
     #                                     trainable=False)
-    sparse_flow = tf.Variable(tf.reshape(sparse_flow, [-1]), trainable=False)
+    zeros = lambda: tf.zeros(tf.reduce_prod(gt_flow.shape), dtype=tf.float32)
+    sparse_flow = tf.Variable(initial_value=zeros, dtype=tf.float32, trainable=False)
     print("sparse_uniform")
     print("sparse_flow.shape: {}\nsampling_mask_flatten_where.shape: {}\ngt_flow_sampling_mask.shape: {}".format(
         sparse_flow.shape, sampling_mask_flatten_where.shape, gt_flow_sampling_mask.shape))

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -332,7 +332,7 @@ def set_range_to_zero(matches, width, offset_h, offset_w, crop_h, crop_w):
     print("range_rows.shape: {}\nrange_cols.shape: {}".format(range_rows.shape, range_cols.shape))
     # Get absolute indices as rows * width + cols
     indices = tf.add(tf.multiply(range_rows, width), range_cols)
-    zeros = tf.zeros(tf.shape(indices))
+    zeros = tf.zeros(tf.shape(indices), dtype=tf.int32)
     print("matches.shape: {}\nindices.shape: {}\nzeros.shape: {}".format(matches.shape, indices.shape, zeros.shape))
     print("type(matches): {}\ntype(indices): {}\ntype(zeros): {}".format(type(matches), type(indices), type(zeros)))
     matches = tf.scatter_update(matches, indices, zeros)

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -267,7 +267,7 @@ def sample_sparse_invalid_like(gt_flow, target_density=75, height=384, width=512
     rand_offset_h, rand_offset_w, crop_h, crop_w = get_random_offset_and_crop((height, width), target_density)
 
     # Define matches as 0 inside the random bbox, 255s elsewhere (at training time the mask is normalised to [0,1])
-    matches = 255 * tf.ones((height, width), dtype=tf.int32)
+    matches = 255 * tf.ones((height, width), dtype=tf.float32)
     # matches = 255 * np.ones((height, width), dtype=np.int32)  # (h, w)
     # Assumption: matches is already a flatten array (when inputted to set_range...)
     matches = tf.Variable(tf.reshape(matches, [-1]), trainable=False)
@@ -332,7 +332,7 @@ def set_range_to_zero(matches, width, offset_h, offset_w, crop_h, crop_w):
     print("range_rows.shape: {}\nrange_cols.shape: {}".format(range_rows.shape, range_cols.shape))
     # Get absolute indices as rows * width + cols
     indices = tf.add(tf.multiply(range_rows, width), range_cols)
-    zeros = tf.zeros(tf.shape(indices), dtype=tf.int32)
+    zeros = tf.zeros(tf.shape(indices), dtype=tf.float32)
     print("matches.shape: {}\nindices.shape: {}\nzeros.shape: {}".format(matches.shape, indices.shape, zeros.shape))
     print("type(matches): {}\ntype(indices): {}\ntype(zeros): {}".format(type(matches), type(indices), type(zeros)))
     matches = tf.scatter_update(matches, indices, zeros)

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -267,10 +267,10 @@ def sample_sparse_invalid_like(gt_flow, target_density=75, height=384, width=512
     rand_offset_h, rand_offset_w, crop_h, crop_w = get_random_offset_and_crop((height, width), target_density)
 
     # Define matches as 0 inside the random bbox, 255s elsewhere (at training time the mask is normalised to [0,1])
-    matches = tf.Variable(255 * tf.ones((height, width), dtype=tf.int32))
+    matches = 255 * tf.ones((height, width), dtype=tf.int32)
     # matches = 255 * np.ones((height, width), dtype=np.int32)  # (h, w)
     # Assumption: matches is already a flatten array (when inputted to set_range...)
-    matches = tf.reshape(matches, [-1])
+    matches = tf.Variable(tf.reshape(matches, [-1]), trainable=False)
     matches = set_range_to_zero(matches, width, rand_offset_h, rand_offset_w, crop_h, crop_w)
     # Convert back to (height, width)
     matches = tf.reshape(matches, (height, width))
@@ -439,8 +439,8 @@ def sample_from_distribution(distrib_id, density, dm_matches, dm_flow, gt_flow):
     sample_dm = tf.cond(tf.logical_and(tf.greater_equal(tf.random_uniform([], maxval=2, dtype=tf.int32), tf.constant(0)),  # 0 or 1
                         tf.less_equal(density, tf.constant(1.0))), lambda: tf.constant(True), lambda: tf.constant(False))
     # sample_dm = tf.cond(True if (np.random.choice([0, 1]) > 0 and density <= 1) else False  # tf.random_uniform([], maxval=2, dtype=tf.int32)  # 0 or 1
-    tf.print("sample_dm: {}".format(sample_dm))
-    tf.print("distrib_id: {}".format(distrib_id))
+    print("sample_dm: {}".format(sample_dm))
+    print("distrib_id: {}".format(distrib_id))
     matches, sparse_flow = tf.case(
         {tf.logical_and(tf.equal(distrib_id, tf.constant(0)),
                         tf.equal(sample_dm, tf.constant(True))): sample_sparse_grid_like(gt_flow, target_density=density,

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -324,8 +324,8 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     sparse_flow = tf.reshape(sparse_flow, [-1])
     print("sparse_flow.shape: {}\nsampling_mask_flatten_where.shape: {}\ngt_flow_sampling_mask.shape: {}".format(
         sparse_flow.shape, sampling_mask_flatten_where.shape, gt_flow_sampling_mask.shape))
-    print("type(sparse_flow): {}\ntype(sampling_mask_flatten[0]): {}\ntype(gt_flow_sampling_mask): {}".format(
-        type(sparse_flow), type(sampling_mask_flatten_where), type(gt_flow_sampling_mask)))
+    # print("type(sparse_flow): {}\ntype(sampling_mask_flatten[0]): {}\ntype(gt_flow_sampling_mask): {}".format(
+    #     type(sparse_flow), type(sampling_mask_flatten_where), type(gt_flow_sampling_mask)))
     sparse_flow = tf.scatter_update(sparse_flow, sampling_mask_flatten_where, gt_flow_sampling_mask)
     sparse_flow = tf.reshape(sparse_flow, gt_flow.shape)
 

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -282,7 +282,7 @@ def sample_sparse_invalid_like(gt_flow, target_density=75, height=384, width=512
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
-    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, 255.0))
+    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.cast(255, dtype=tf.int32)))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
@@ -315,7 +315,7 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
-    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, 255))
+    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.cast(255, dtype=tf.int32)))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
@@ -333,6 +333,8 @@ def set_range_to_zero(matches, width, offset_h, offset_w, crop_h, crop_w):
     indices = tf.add(tf.multiply(range_rows, width), range_cols)
     zeros = tf.zeros(tf.shape(indices))
     matches = tf.scatter_update(matches, indices, zeros)
+    tf.print("matches.shape: {}\nindices.shape: {}\nzeros.shape: {}".format(matches.shape, indices.shape, zeros.shape))
+    tf.print("type(matches): {}\ntype(indices): {}\ntype(zeros): {}".format(type(matches), type(indices), type(zeros)))
     # numpy: matches[rand_offset_h:rand_offset_h + crop_h, rand_offset_w: rand_offset_w + crop_w] = 0
     return matches
 
@@ -393,8 +395,7 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
     two_five_five = 255 * tf.ones(tf.shape(indices))
     matches = tf.Variable(tf.reshape(matches, [-1]), trainable=False)
     # matches = np.zeros((height, width), dtype=np.int32)
-    tf.print("matches.shape: {}\nindices.shape: {}\ntwo_five_five.shape: {}".format(matches.shape, indices.shape,
-                                                                                    two_five_five.shape))
+
     matches = tf.scatter_update(matches, indices, two_five_five)  # all 1D tensors
     # matches[yy_flatten, xx_flatten] = 255
     # matches = tf.reshape(matches, (height, width, 1))
@@ -413,7 +414,7 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
-    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, 255))
+    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.cast(255, dtype=tf.int32)))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -282,7 +282,7 @@ def sample_sparse_invalid_like(gt_flow, target_density=75, height=384, width=512
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
-    sampling_mask_flatten = tf.compat.v2.where(tf.equal(sampling_mask_flatten, tf.constant(255)))
+    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.constant(255)))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
@@ -315,7 +315,7 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
-    sampling_mask_flatten = tf.compat.v2.where(tf.equal(sampling_mask_flatten, tf.constant(255)))
+    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.constant(255)))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
@@ -413,7 +413,7 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
-    sampling_mask_flatten = tf.compat.v2.where(tf.equal(sampling_mask_flatten, tf.constant(255)))
+    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.constant(255)))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -316,16 +316,17 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
-    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.cast(255, dtype=sampling_mask_flatten.dtype)))
+    sampling_mask_flatten_where = tf.where(tf.equal(sampling_mask_flatten, tf.cast(1, dtype=sampling_mask_flatten.dtype)))
+    sampling_mask_flatten_where = tf.reshape(sampling_mask_flatten_where, [-1])
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
     sparse_flow = tf.reshape(sparse_flow, [-1])
-    print("sparse_flow.shape: {}\nsampling_mask_flatten[0].shape: {}\ngt_flow_sampling_mask.shape: {}".format(
-        sparse_flow.shape, sampling_mask_flatten.shape[0], gt_flow_sampling_mask.shape))
+    print("sparse_flow.shape: {}\nsampling_mask_flatten_where.shape: {}\ngt_flow_sampling_mask.shape: {}".format(
+        sparse_flow.shape, sampling_mask_flatten_where.shape, gt_flow_sampling_mask.shape))
     print("type(sparse_flow): {}\ntype(sampling_mask_flatten[0]): {}\ntype(gt_flow_sampling_mask): {}".format(
-        type(sparse_flow), type(sampling_mask_flatten[0]), type(gt_flow_sampling_mask)))
-    sparse_flow = tf.scatter_update(sparse_flow, sampling_mask_flatten, gt_flow_sampling_mask)
+        type(sparse_flow), type(sampling_mask_flatten_where), type(gt_flow_sampling_mask)))
+    sparse_flow = tf.scatter_update(sparse_flow, sampling_mask_flatten_where, gt_flow_sampling_mask)
     sparse_flow = tf.reshape(sparse_flow, gt_flow.shape)
 
     return matches, sparse_flow

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -201,6 +201,8 @@ def flow_resize(flow, out_size, is_scale=True, method=0):
 def sample_gt_flow_to_sparse(gt_flow, target_density=75, target_distribution='uniform'):
     gt_flow_size = tf.cast(tf.shape(gt_flow)[1:-1], tf.int32)  # height and width only
     # sparse_flow = tf.zeros(tf.shape(gt_flow), dtype=tf.float32)
+    sess = tf.Session()
+    sess.run(tf.constant(gt_flow))
     sparse_flow = np.zeros(gt_flow.shape).astype(np.float32)
     p_fill = target_density / 100  # target_density expressed in %
     if target_distribution.lower() == 'uniform':
@@ -222,5 +224,6 @@ def sample_gt_flow_to_sparse(gt_flow, target_density=75, target_distribution='un
     sparse_flow[random_mask_rep] = gt_flow[random_mask_rep]
     sparse_flow = tf.convert_to_tensor(sparse_flow, name='sparse_flow')
     # sparse_flow = tf.scatter_update(sparse_flow, pixel_idxs, gt_flow_pixel_idxs)
+    gt_flow = tf.convert_to_tensor(gt_flow, name='gt_flow')
 
-    return sparse_flow
+    return sparse_flow, gt_flow

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -344,11 +344,9 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
     # if num_samples_h > height or num_samples_w > width:
     #     num_samples_h = height if num_samples_h > height else num_samples_h
     #     num_samples_w = width if num_samples_w > width else num_samples_w
-    sample_points_h = tf.linspace(tf.constant(0, dtype=tf.int32), tf.constant(height - 1, dtype=tf.int32),
-                                  num_samples_h)
+    sample_points_h = tf.range(0, height - 1, num_samples_h, dtype=tf.int32)
     # sample_points_h = np.linspace(0, height - 1, num_samples_h, dtype=np.int32)
-    sample_points_w = tf.linspace(tf.constant(0, dtype=tf.int32), tf.constant(width - 1, dtype=tf.int32),
-                                  num_samples_w)
+    sample_points_w = tf.range(0, width - 1, num_samples_w, dtype=tf.int32)
     # sample_points_w = np.linspace(0, width - 1, num_samples_w, dtype=np.int32)
     # Create meshgrid of all combinations (i.e.: coordinates to sample at)
     # matches = tf.zeros((height, width), dtype=tf.int32)

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -457,8 +457,8 @@ def return_identity_one(x):
 
 def sample_from_distribution(distrib_id, density, dm_matches, dm_flow, gt_flow):
     height, width, _ = gt_flow.get_shape().as_list()
-
-    sample_dm = tf.cond(tf.logical_and(tf.greater_equal(tf.random_uniform([], maxval=2, dtype=tf.int32), tf.constant(0)),  # 0 or 1
+    aux_choice = tf.random_uniform([], maxval=2, dtype=tf.int32)  # 0 or 1
+    sample_dm = tf.cond(tf.logical_and(tf.greater(aux_choice, tf.constant(0)),
                         tf.less_equal(density, tf.constant(1.0))), lambda: tf.constant(True), lambda: tf.constant(False))
     # sample_dm = tf.cond(True if (np.random.choice([0, 1]) > 0 and density <= 1) else False  # tf.random_uniform([], maxval=2, dtype=tf.int32)  # 0 or 1
     matches, sparse_flow = tf.case(
@@ -494,9 +494,11 @@ def sample_sparse_flow(dm_matches, dm_flow, gt_flow, num_ranges=6, num_distrib=3
     density = tf.zeros([], dtype=tf.float32)
     density = apply_with_random_selector(density, lambda x, ordering: get_sampling_density(x, ordering, fast_mode),
                                          num_cases=num_ranges)
+    tf.summary.scalar('train/density', density)
 
     # Select a distribution (random uniform, invalid like or grid like with holes
     distrib_id = tf.random_uniform([], maxval=num_distrib, dtype=tf.int32)  # np.random.choice(range(num_distrib))
+    tf.summary.scalar('train/distrib_id', distrib_id)
     matches, sparse_flow = sample_from_distribution(distrib_id, density, dm_matches, dm_flow, gt_flow)
 
     return matches, sparse_flow

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -199,12 +199,18 @@ def flow_resize(flow, out_size, is_scale=True, method=0):
 
 # Functions to sample ground truth flow with different density and probability distribution
 def sample_gt_flow_to_sparse(gt_flow, target_density=75, target_distribution='uniform'):
+    """
+    :param gt_flow: tensor containing ground truth optical flow (before batching ==> shape: (h, w, 2) )
+    :param target_density:
+    :param target_distribution:
+    :return:
+    """
     sparse_flow = tf.Variable(tf.zeros(gt_flow.shape, dtype=tf.float32), trainable=False)
     p_fill = target_density / 100  # target_density expressed in %
     if target_distribution.lower() == 'uniform':
         sampling_mask = np.random.choice([0, 1], size=gt_flow.shape[:-1], p=[1 - p_fill, p_fill]).astype(
             np.int32)
-        sampling_mask = np.repeat(sampling_mask[:, :, :, np.newaxis], 2, axis=-1)
+        sampling_mask = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
         sampling_mask = np.reshape(sampling_mask, [-1])
         sampling_mask = np.where(sampling_mask == 1)
 

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -305,7 +305,7 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     sparse_flow = tf.Variable(tf.zeros(gt_flow.shape, dtype=tf.float32), trainable=False)
     p_fill = tf.divide(target_density, 100.0)
     # p_fill = target_density / 100  # target_density expressed in %
-    samples = tf.random.categorical(tf.log([[1 - p_fill, p_fill]]), height * width)  # note log-prob
+    samples = tf.multinomial(tf.log([[1 - p_fill, p_fill]]), height * width)  # note log-prob
     sampling_mask = tf.cast(tf.reshape(samples, (height, width)), dtype=tf.int32)
     # sampling_mask = np.random.choice([0, 255], size=(height, width), p=[1 - p_fill, p_fill]).astype(
     #     np.int32)  # sampling_mask.shape: (h, w)

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -386,7 +386,7 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
     # yy_flatten = yy.flatten()
     # Compute absolute indices as row * width + cols
     indices = tf.add(tf.multiply(rows_flatten, matches.shape[1]), cols_flatten)
-    two_five_five = tf.Variable(255 * tf.ones(tf.shape(indices)), trainable=False)
+    two_five_five = 255 * tf.ones(tf.shape(indices))
     matches = tf.scatter_nd_update(matches, indices, two_five_five)
     # matches[yy_flatten, xx_flatten] = 255
 

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -321,7 +321,8 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     sampling_mask_flatten_where = tf.reshape(sampling_mask_flatten_where, [-1])
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 1)
     gt_flow_boolean_mask = lambda: tf.boolean_mask(gt_flow, sampling_mask_rep)
-    gt_flow_sampling_mask = tf.Variable(initial_value=gt_flow_boolean_mask, dtype=tf.float32, trainable=False)
+    gt_flow_sampling_mask = tf.Variable(initial_value=gt_flow_boolean_mask, dtype=tf.float32, validate_shape=False,
+                                        trainable=False)
     sparse_flow = tf.reshape(sparse_flow, [-1])
     print("sparse_uniform")
     print("sparse_flow.shape: {}\nsampling_mask_flatten_where.shape: {}\ngt_flow_sampling_mask.shape: {}".format(

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -302,7 +302,8 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     :param target_density:
     :return:
     """
-    sparse_flow = tf.Variable(tf.zeros(gt_flow.shape, dtype=tf.float32), trainable=False)
+    zeros = lambda: tf.zeros(gt_flow.shape, dtype=tf.float32)
+    sparse_flow = tf.Variable(initial_value=zeros, dtype=tf.float32, trainable=False)
     p_fill = tf.divide(target_density, 100.0)
     # p_fill = target_density / 100  # target_density expressed in %
     samples = tf.multinomial(tf.log([[1 - p_fill, p_fill]]), height * width)  # note log-prob

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -226,6 +226,7 @@ def sample_gt_flow_to_sparse(gt_flow, target_density=75, target_distribution='un
     # gt_flow_pixel_idxs = tf.cast(tf.boolean_mask(gt_flow, sampling_mask_logical), dtype=tf.float32)
     print(sparse_flow.shape)
     print(gt_flow.shape)
+    print("gt_flow/spars_flow [masked]")
     print(gt_flow[random_mask_rep].shape)
     print(sparse_flow[random_mask_rep].shape)
     sparse_flow[random_mask_rep] = gt_flow[random_mask_rep]

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -427,11 +427,11 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
 
 
 def return_identity(x, y):
-    return x, y
+    return tf.identity(x), tf.identity(y)
 
 
 def return_identity_one(x):
-    return x
+    return tf.identity(x)
 
 
 def sample_from_distribution(distrib_id, density, dm_matches, dm_flow, gt_flow):
@@ -443,15 +443,16 @@ def sample_from_distribution(distrib_id, density, dm_matches, dm_flow, gt_flow):
     print("distrib_id: {}".format(distrib_id))
     matches, sparse_flow = tf.case(
         {tf.logical_and(tf.equal(distrib_id, tf.constant(0)),
-                        tf.equal(sample_dm, tf.constant(True))): sample_sparse_grid_like(gt_flow, target_density=density,
-                                                                                         height=height, width=width),
-         tf.logical_and(tf.equal(distrib_id, tf.constant(0)), tf.equal(sample_dm, tf.constant(False))): return_identity(
-             dm_matches, dm_flow),
-         tf.equal(distrib_id, tf.constant(1)): sample_sparse_uniform(gt_flow, target_density=density, height=height,
-                                                                     width=width),
-         tf.equal(distrib_id, tf.constant(2)): sample_sparse_invalid_like(gt_flow, target_density=density, height=height,
-                                                                          width=width)},
-        default=sample_sparse_uniform(gt_flow, target_density=density, height=height, width=width), exclusive=True)
+                        tf.equal(sample_dm, tf.constant(True))): lambda: sample_sparse_grid_like(
+            gt_flow, target_density=density, height=height, width=width),
+         tf.logical_and(tf.equal(distrib_id, tf.constant(0)),
+                        tf.equal(sample_dm, tf.constant(False))): lambda: return_identity(dm_matches, dm_flow),
+         tf.equal(distrib_id, tf.constant(1)): lambda: sample_sparse_uniform(gt_flow, target_density=density,
+                                                                             height=height, width=width),
+         tf.equal(distrib_id, tf.constant(2)): lambda: sample_sparse_invalid_like(gt_flow, target_density=density,
+                                                                                  height=height, width=width)},
+        default=lambda: sample_sparse_uniform(gt_flow, target_density=density, height=height, width=width),
+        exclusive=True)
 
     return matches, sparse_flow
 

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -307,10 +307,14 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     """
     p_fill = tf.divide(target_density, 100.0)
     # p_fill = target_density / 100  # target_density expressed in %
+    print("p_fill: {}".format(p_fill))
     samples = tf.multinomial(tf.log([[1 - p_fill, p_fill]]), height * width)  # note log-prob
+    print("samples: {}".format(samples))
+    print("samples.shape: {}".format(samples.shape))
     sampling_mask = tf.cast(tf.reshape(samples, (height, width)), dtype=tf.int32)
     # sampling_mask = np.random.choice([0, 255], size=(height, width), p=[1 - p_fill, p_fill]).astype(
     #     np.int32)  # sampling_mask.shape: (h, w)
+    print("(approx. equal to p_fill) sum(sampling_mask) / image_shape: {}".format(tf.reduce_sum(sampling_mask) / (height * width)))
     matches = tf.cast(tf.expand_dims(sampling_mask, -1), dtype=tf.float32)  # convert to (h, w, 1)
     sampling_mask = sampling_mask[:, :, tf.newaxis]
     print("before tf.tile: sampling_mask.shape: {}".format(sampling_mask.shape))

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -229,7 +229,7 @@ def get_random_offset_and_crop(image_shape, density):
     # aspect_ratios = [16 / 9, 4 / 3, 3 / 2, 3 / 1, 4 / 5]
     num_aspect_ratios = 5
     aspect_ratios = tf.constant([16 / 9, 4 / 3, 3 / 2, 3 / 1, 4 / 5])
-    aspect_id = tf.random_uniform([], maxval=aspect_ratios+1, dtype=tf.int32)  # np.random.choice(range(len(aspect_ratios)))
+    aspect_id = tf.random_uniform([], maxval=num_aspect_ratios+1, dtype=tf.int32)  # np.random.choice(range(len(aspect_ratios)))
     aspect_ratio = aspect_ratios[aspect_id]
     # Compute width and height based of random aspect ratio and bbox area
     # bbox = w * h, AR = w/h

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -321,6 +321,10 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
     sparse_flow = tf.reshape(sparse_flow, [-1])
+    print("sparse_flow.shape: {}\nsampling_mask_flatten[0].shape: {}\ngt_flow_sampling_mask.shape: {}".format(
+        sparse_flow.shape, sampling_mask_flatten[0].shape, gt_flow_sampling_mask.shape))
+    print("type(sparse_flow): {}\ntype(sampling_mask_flatten[0]): {}\ntype(gt_flow_sampling_mask): {}".format(
+        type(sparse_flow), type(sampling_mask_flatten[0]), type(gt_flow_sampling_mask)))
     sparse_flow = tf.scatter_update(sparse_flow, sampling_mask_flatten[0], gt_flow_sampling_mask)
     sparse_flow = tf.reshape(sparse_flow, gt_flow.shape)
 

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -285,7 +285,7 @@ def sample_sparse_invalid_like(gt_flow, target_density=75, height=384, width=512
     sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.cast(255, dtype=sampling_mask_flatten.dtype)))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
-    gt_flow_sampling_mask = tf.Variable(tf.boolean_mask(gt_flow, sampling_mask_rep), trainable=False)
+    gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
     sparse_flow = tf.Variable(tf.reshape(sparse_flow, [-1]), trainable=False)
     sparse_flow = tf.scatter_update(sparse_flow, sampling_mask_flatten[0], gt_flow_sampling_mask)
     sparse_flow = tf.reshape(sparse_flow, gt_flow.shape)
@@ -318,7 +318,7 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.cast(255, dtype=sampling_mask_flatten.dtype)))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
-    gt_flow_sampling_mask = tf.Variable(tf.boolean_mask(gt_flow, sampling_mask_rep), trainable=False)
+    gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
     sparse_flow = tf.Variable(tf.reshape(sparse_flow, [-1]), trainable=False)
     sparse_flow = tf.scatter_update(sparse_flow, sampling_mask_flatten[0], gt_flow_sampling_mask)
     sparse_flow = tf.reshape(sparse_flow, gt_flow.shape)

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -271,7 +271,7 @@ def sample_sparse_invalid_like(gt_flow, target_density=75, height=384, width=512
     # matches = 255 * np.ones((height, width), dtype=np.int32)  # (h, w)
     # Assumption: matches is already a flatten array (when inputted to set_range...)
     matches = tf.reshape(matches, [-1])
-    matches = set_range_to_zero(matches, rand_offset_h, rand_offset_w, crop_h, crop_w)
+    matches = set_range_to_zero(matches, width, rand_offset_h, rand_offset_w, crop_h, crop_w)
     # Convert back to (height, width)
     matches = tf.reshape(matches, (height, width))
     # matches[rand_offset_h:rand_offset_h + crop_h, rand_offset_w: rand_offset_w + crop_w] = 0
@@ -326,11 +326,11 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     return matches, sparse_flow
 
 
-def set_range_to_zero(matches, offset_h, offset_w, crop_h, crop_w):
+def set_range_to_zero(matches, width, offset_h, offset_w, crop_h, crop_w):
     range_rows = tf.range(offset_h, offset_h + crop_h)
     range_cols = tf.range(offset_w, offset_w + crop_w)
     # Get absolute indices as rows * width + cols
-    indices = tf.add(tf.multiply(range_rows, matches.shape[1]), range_cols)
+    indices = tf.add(tf.multiply(range_rows, width), range_cols)
     zeros = tf.zeros(tf.shape(indices))
     matches = tf.scatter_update(matches, indices, zeros)
     # numpy: matches[rand_offset_h:rand_offset_h + crop_h, rand_offset_w: rand_offset_w + crop_w] = 0
@@ -342,7 +342,7 @@ def corrupt_sparse_flow(matches, density, height=384, width=512):
     inv_fraction = 10.0
     rand_offset_h, rand_offset_w, crop_h, crop_w = get_random_offset_and_crop((height, width),
                                                                               tf.divide(density, inv_fraction))
-    matches = set_range_to_zero(matches, rand_offset_h, rand_offset_w, crop_h, crop_w)
+    matches = set_range_to_zero(matches, width, rand_offset_h, rand_offset_w, crop_h, crop_w)
     return matches
 
 

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -382,7 +382,6 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
     """
     # Important: matches is already normalised to [0, 1]
     # sparse_flow = tf.Variable(tf.zeros(gt_flow.shape, dtype=tf.float32), trainable=False)
-    matches = tf.zeros((height, width, 1), dtype=tf.float32)
     num_samples = tf.multiply(tf.multiply(tf.divide(target_density, 100.0), height), width)
     # num_samples = (target_density / 100) * height * width
     aspect_ratio = tf.divide(width, height)
@@ -420,7 +419,8 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
     indices = tf.add(tf.multiply(rows_flatten, width), cols_flatten)
     ones_raw = lambda: tf.ones(tf.shape(indices))
     ones = tf.Variable(initial_value=ones_raw, trainable=False, validate_shape=False)
-    matches = tf.Variable(tf.reshape(matches, [-1]), trainable=False)
+    zeros = lambda: tf.zeros((height * width), dtype=tf.float32)
+    matches = tf.Variable(initial_value=zeros, trainable=False)
     # matches = np.zeros((height, width), dtype=np.int32)
 
     matches = tf.scatter_update(matches, indices, ones)  # all 1D tensors

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -369,8 +369,8 @@ def return_identity(x, y):
 
 def sample_from_distribution(distrib_id, density, dm_matches, dm_flow, gt_flow):
     height, width, _ = gt_flow.get_shape().as_list()
-    sample_dm = tf.cond(tf.logical_and(tf.random_uniform([], maxval=2, dtype=tf.int32)),  # 0 or 1
-                        tf.less_equal(density, tf.constant(1)), lambda: tf.constant(True), lambda: tf.constant(False))
+    sample_dm = tf.cond(tf.logical_and(tf.random_uniform([], maxval=2, dtype=tf.int32),  # 0 or 1
+                        tf.less_equal(density, tf.constant(1))), lambda: tf.constant(True), lambda: tf.constant(False))
     # sample_dm = tf.cond(True if (np.random.choice([0, 1]) > 0 and density <= 1) else False  # tf.random_uniform([], maxval=2, dtype=tf.int32)  # 0 or 1
     tf.print("sample_dm: {}".format(sample_dm))
     tf.print("distrib_id: {}".format(distrib_id))

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -354,19 +354,19 @@ def sample_sparse_flow(dm_matches, dm_flow, gt_flow, num_ranges=6, num_distrib=3
     :return:
     """
     # Sample a id which selects a "subrange" of density
-    density_id = tf.random_uniform([], maxval=num_ranges, dtype=tf.int32)
+    density_id = np.random.choice(range(num_ranges))  # tf.random_uniform([], maxval=num_ranges, dtype=tf.int32)
     if density_id == 0:  # very sparse matches (from 0.001 to 1% of the image area)
-        density = tf.random_uniform([], minval=0.01, maxval=1., dtype=tf.float32)
+        density = np.random.uniform(low=0.01, high=1.)  # tf.random_uniform([], minval=0.01, maxval=1., dtype=tf.float32)
     elif density_id == 1:  # quite sparse matches (from 1 to 10% of the image area)
-        density = tf.random_uniform([], minval=1., maxval=10., dtype=tf.float32)
+        density = np.random.uniform(low=1., high=10.)  # tf.random_uniform([], minval=1., maxval=10., dtype=tf.float32)
     elif density_id == 2:  # semi-sparse matches (from 10 to 25% of the image area)
-        density = tf.random_uniform([], minval=10., maxval=25., dtype=tf.float32)
+        density = np.random.uniform(low=10., high=25.)  # tf.random_uniform([], minval=10., maxval=25., dtype=tf.float32)
     elif density_id == 3:  # semi-dense matches (from 25 to 50% of the image area)
-        density = tf.random_uniform([], minval=25., maxval=50., dtype=tf.float32)
+        density = np.random.uniform(low=25., high=50.)  # tf.random_uniform([], minval=25., maxval=50., dtype=tf.float32)
     elif density_id == 4:  # quite dense matches (from 50 to 75% of the image area)
-        density = tf.random_uniform([], minval=50., maxval=75., dtype=tf.float32)
+        density = np.random.uniform(low=50., high=75.)  # tf.random_uniform([], minval=50., maxval=75., dtype=tf.float32)
     elif density_id == 5:  # very dense matches (from 75 to 90% of the image area)
-        density = tf.random_uniform([], minval=75., maxval=90., dtype=tf.float32)
+        density = np.random.uniform(low=75., high=90.)  # tf.random_uniform([], minval=75., maxval=90., dtype=tf.float32)
     else:
         raise ValueError("FATAL: id should have been an integer within (0-5) but instead was {}".format(density_id))
 

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -332,9 +332,9 @@ def set_range_to_zero(matches, width, offset_h, offset_w, crop_h, crop_w):
     # Get absolute indices as rows * width + cols
     indices = tf.add(tf.multiply(range_rows, width), range_cols)
     zeros = tf.zeros(tf.shape(indices))
-    matches = tf.scatter_update(matches, indices, zeros)
     tf.print("matches.shape: {}\nindices.shape: {}\nzeros.shape: {}".format(matches.shape, indices.shape, zeros.shape))
     tf.print("type(matches): {}\ntype(indices): {}\ntype(zeros): {}".format(type(matches), type(indices), type(zeros)))
+    matches = tf.scatter_update(matches, indices, zeros)
     # numpy: matches[rand_offset_h:rand_offset_h + crop_h, rand_offset_w: rand_offset_w + crop_w] = 0
     return matches
 

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -233,7 +233,7 @@ def sample_sparse_invalid_like(gt_flow, target_density=75, height=384, width=512
     :param target_density:
     :return:
     """
-    sparse_flow = tf.Variable(tf.zeros((height, width), dtype=tf.float32), trainable=False)
+    sparse_flow = tf.Variable(tf.zeros(gt_flow.shape, dtype=tf.float32), trainable=False)
     rand_offset_h, rand_offset_w, crop_h, crop_w = get_random_offset_and_crop((height, width), target_density)
 
     # Define matches as 0 inside the random bbox, 255s elsewhere (at training time the mask is normalised to [0,1])
@@ -262,7 +262,7 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     :param target_density:
     :return:
     """
-    sparse_flow = tf.Variable(tf.zeros((height, width), dtype=tf.float32), trainable=False)
+    sparse_flow = tf.Variable(tf.zeros(gt_flow.shape, dtype=tf.float32), trainable=False)
     p_fill = target_density / 100  # target_density expressed in %
     sampling_mask = np.random.choice([0, 255], size=(height, width), p=[1 - p_fill, p_fill]).astype(
         np.int32)  # sampling_mask.shape: (h, w)
@@ -286,7 +286,7 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
     :param target_density:
     :return:
     """
-    sparse_flow = tf.Variable(tf.zeros((height, width), dtype=tf.float32), trainable=False)
+    sparse_flow = tf.Variable(tf.zeros(gt_flow.shape, dtype=tf.float32), trainable=False)
     num_samples = (target_density / 100) * height * width
     aspect_ratio = width / height
     # Compute as in invalid_like for a random box to know the number of samples in horizontal and vertical
@@ -301,7 +301,7 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
     sample_points_h = np.linspace(0, height - 1, num_samples_h, dtype=np.int32)
     sample_points_w = np.linspace(0, width - 1, num_samples_w, dtype=np.int32)
     # Create meshgrid of all combinations (i.e.: coordinates to sample at)
-    matches = np.zeros((height, width), dtype=np.uint8)
+    matches = np.zeros((height, width), dtype=np.int32)
     xx, yy = np.meshgrid(sample_points_w, sample_points_h)
     xx_flatten = xx.flatten()
     yy_flatten = yy.flatten()

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -369,8 +369,9 @@ def return_identity(x, y):
 
 def sample_from_distribution(distrib_id, density, dm_matches, dm_flow, gt_flow):
     height, width, _ = gt_flow.get_shape().as_list()
-
-    sample_dm = True if (np.random.choice([0, 1]) > 0 and density <= 1) else False  # tf.random_uniform([], maxval=2, dtype=tf.int32)  # 0 or 1
+    sample_dm = tf.cond(tf.logical_and(tf.random_uniform([], maxval=2, dtype=tf.int32)),  # 0 or 1
+                        tf.less_equal(density, tf.constant(1)), lambda: tf.constant(True), lambda: tf.constant(False))
+    # sample_dm = tf.cond(True if (np.random.choice([0, 1]) > 0 and density <= 1) else False  # tf.random_uniform([], maxval=2, dtype=tf.int32)  # 0 or 1
     tf.print("sample_dm: {}".format(sample_dm))
     tf.print("distrib_id: {}".format(distrib_id))
     matches, sparse_flow = tf.case(
@@ -385,21 +386,6 @@ def sample_from_distribution(distrib_id, density, dm_matches, dm_flow, gt_flow):
                                                                           width=width)},
         default=sample_sparse_uniform(gt_flow, target_density=density, height=height, width=width), exclusive=True)
 
-    # if distrib_id == 0:  # grid-like + random holes
-    #     if density <= 1 and np.random.choice([0, 1]) == 0:  # use 'raw' DeepMatches
-    #         sparse_flow = dm_flow
-    #         matches = dm_matches
-    #     else:
-    #         matches, sparse_flow = sample_sparse_grid_like(gt_flow, target_density=density, height=height, width=width)
-    #
-    # elif distrib_id == 1:  # random uniform
-    #     matches, sparse_flow = sample_sparse_uniform(gt_flow, target_density=density, height=height, width=width)
-    #
-    # elif distrib_id == 2:  # invalid-like (either 100% dense in known areas or 0% in unknown ones (holes))
-    #     matches, sparse_flow = sample_sparse_invalid_like(gt_flow, target_density=density, height=height, width=width)
-    # else:
-    #     raise ValueError("FATAL: id should have been an integer within (0-5) but instead was {}".format(distrib_id))
-
     return matches, sparse_flow
 
 
@@ -413,23 +399,6 @@ def sample_sparse_flow(dm_matches, dm_flow, gt_flow, num_ranges=6, num_distrib=3
     density = tf.zeros([], dtype=tf.float32)
     density = apply_with_random_selector(density, lambda x, ordering: get_sampling_density(x, ordering, fast_mode),
                                          num_cases=num_ranges)
-    # # Sample a id which selects a "subrange" of density
-    # density_id = np.random.choice(range(num_ranges))  # tf.random_uniform([], maxval=num_ranges, dtype=tf.int32)
-    # if density_id == 0:  # very sparse matches (from 0.001 to 1% of the image area)
-    #     density = np.random.uniform(low=0.01, high=1.)  # tf.random_uniform([], minval=0.01, maxval=1., dtype=tf.float32)
-    # elif density_id == 1:  # quite sparse matches (from 1 to 10% of the image area)
-    #     density = np.random.uniform(low=1., high=10.)  # tf.random_uniform([], minval=1., maxval=10., dtype=tf.float32)
-    # elif density_id == 2:  # semi-sparse matches (from 10 to 25% of the image area)
-    #     density = np.random.uniform(low=10., high=25.)  # tf.random_uniform([], minval=10., maxval=25., dtype=tf.float32)
-    # elif density_id == 3:  # semi-dense matches (from 25 to 50% of the image area)
-    #     density = np.random.uniform(low=25., high=50.)  # tf.random_uniform([], minval=25., maxval=50., dtype=tf.float32)
-    # elif density_id == 4:  # quite dense matches (from 50 to 75% of the image area)
-    #     density = np.random.uniform(low=50., high=75.)  # tf.random_uniform([], minval=50., maxval=75., dtype=tf.float32)
-    # elif density_id == 5:  # very dense matches (from 75 to 90% of the image area)
-    #     density = np.random.uniform(low=75., high=90.)  # tf.random_uniform([], minval=75., maxval=90., dtype=tf.float32)
-    # else:
-    #     raise ValueError("FATAL: id should have been an integer within (0-5) but instead was {}".format(density_id))
-    # print("density_id: {}\ndensity: {:.2f}%".format(density_id, density))
 
     # Select a distribution (random uniform, invalid like or grid like with holes
     distrib_id = tf.random_uniform([], maxval=num_distrib, dtype=tf.int32)  # np.random.choice(range(num_distrib))

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -323,7 +323,7 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
     :return:
     """
     sparse_flow = tf.Variable(tf.zeros(gt_flow.shape, dtype=tf.float32), trainable=False)
-    num_samples = tf.multiply(tf.multiply(tf.divide(target_density, 100, height)), width)
+    num_samples = tf.multiply(tf.multiply(tf.divide(target_density, 100), height), width)
     # num_samples = (target_density / 100) * height * width
     aspect_ratio = tf.divide(width, height)
     # Compute as in invalid_like for a random box to know the number of samples in horizontal and vertical

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -315,7 +315,7 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
-    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, 255.0))
+    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, 255))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
@@ -413,7 +413,7 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
-    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, 255.0))
+    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, 255))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -206,22 +206,24 @@ def sample_gt_flow_to_sparse(gt_flow, target_density=75, target_distribution='un
     sparse_flow = np.zeros(gt_flow.shape).astype(np.float32)
     p_fill = target_density / 100  # target_density expressed in %
     if target_distribution.lower() == 'uniform':
-      sampling_mask = np.random.choice([0, 255], size=gt_flow.shape[:-1], p=[1 - p_fill, p_fill]).astype(
-                    np.uint8)
-      random_mask = sampling_mask == 255
-      tf.print(gt_flow.shape)
-      random_mask_rep = np.repeat(random_mask[:, :, :, np.newaxis], 2, axis=-1)
-      #tf.print(sampling_mask)
-#       sampling_mask_logical = sampling_mask == 1
-#       pixel_idxs = np.where(sampling_mask == 1)
-      # sampling_mask = tf.convert_to_tensor(sampling_mask_logical, name='sampling_mask')
-        # sampling_mask = tf.random_uniform(gt_flow.shape, minval=0, maxval=1, dtype=tf.int32)
+        sampling_mask = np.random.choice([0, 255], size=gt_flow.shape[:-1], p=[1 - p_fill, p_fill]).astype(
+            np.uint8)
+        random_mask = sampling_mask == 255
+        random_mask_rep = np.repeat(random_mask[:, :, :, np.newaxis], 2, axis=-1)
+        tf.print(random_mask_rep.shape)
+        #tf.print(sampling_mask)
+    #       sampling_mask_logical = sampling_mask == 1
+    #       pixel_idxs = np.where(sampling_mask == 1)
+    # sampling_mask = tf.convert_to_tensor(sampling_mask_logical, name='sampling_mask')
+    # sampling_mask = tf.random_uniform(gt_flow.shape, minval=0, maxval=1, dtype=tf.int32)
 
     # conditioned_pixels = tf.equal(sampling_mask, tf.constant(1))
     # pixel_idxs = tf.where(conditioned_pixels)
-#     pixel_idxs = tf.convert_to_tensor(pixel_idxs, name='pixel_idxs')
-#     sampling_mask_logical = tf.convert_to_tensor(sampling_mask_logical, name='sampling_mask_logical')
+    #     pixel_idxs = tf.convert_to_tensor(pixel_idxs, name='pixel_idxs')
+    #     sampling_mask_logical = tf.convert_to_tensor(sampling_mask_logical, name='sampling_mask_logical')
     # gt_flow_pixel_idxs = tf.cast(tf.boolean_mask(gt_flow, sampling_mask_logical), dtype=tf.float32)
+    tf.print(sparse_flow.shape)
+    tf.print(gt_flow.shape)
     sparse_flow[random_mask_rep] = gt_flow[random_mask_rep]
     sparse_flow = tf.convert_to_tensor(sparse_flow, name='sparse_flow')
     # sparse_flow = tf.scatter_update(sparse_flow, pixel_idxs, gt_flow_pixel_idxs)

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -332,8 +332,8 @@ def set_range_to_zero(matches, width, offset_h, offset_w, crop_h, crop_w):
     # Get absolute indices as rows * width + cols
     indices = tf.add(tf.multiply(range_rows, width), range_cols)
     zeros = tf.zeros(tf.shape(indices))
-    tf.print("matches.shape: {}\nindices.shape: {}\nzeros.shape: {}".format(matches.shape, indices.shape, zeros.shape))
-    tf.print("type(matches): {}\ntype(indices): {}\ntype(zeros): {}".format(type(matches), type(indices), type(zeros)))
+    print("matches.shape: {}\nindices.shape: {}\nzeros.shape: {}".format(matches.shape, indices.shape, zeros.shape))
+    print("type(matches): {}\ntype(indices): {}\ntype(zeros): {}".format(type(matches), type(indices), type(zeros)))
     matches = tf.scatter_update(matches, indices, zeros)
     # numpy: matches[rand_offset_h:rand_offset_h + crop_h, rand_offset_w: rand_offset_w + crop_w] = 0
     return matches

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -369,7 +369,7 @@ def return_identity(x, y):
 
 def sample_from_distribution(distrib_id, density, dm_matches, dm_flow, gt_flow):
     height, width, _ = gt_flow.get_shape().as_list()
-    sample_dm = tf.cond(tf.logical_and(tf.random_uniform([], maxval=2, dtype=tf.int32),  # 0 or 1
+    sample_dm = tf.cond(tf.logical_and(tf.greater_equal(tf.random_uniform([], maxval=2, dtype=tf.int32), tf.constant(0)),  # 0 or 1
                         tf.less_equal(density, tf.constant(1.0))), lambda: tf.constant(True), lambda: tf.constant(False))
     # sample_dm = tf.cond(True if (np.random.choice([0, 1]) > 0 and density <= 1) else False  # tf.random_uniform([], maxval=2, dtype=tf.int32)  # 0 or 1
     tf.print("sample_dm: {}".format(sample_dm))

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -418,7 +418,8 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
 
     # Compute absolute indices as row * width + cols
     indices = tf.add(tf.multiply(rows_flatten, width), cols_flatten)
-    ones = tf.Variable(tf.ones(tf.shape(indices)), trainable=False, validate_shape=False)
+    ones_raw = lambda: tf.ones(tf.shape(indices))
+    ones = tf.Variable(init_value=ones_raw, trainable=False, validate_shape=False)
     matches = tf.Variable(tf.reshape(matches, [-1]), trainable=False)
     # matches = np.zeros((height, width), dtype=np.int32)
 

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -285,7 +285,7 @@ def sample_sparse_invalid_like(gt_flow, target_density=75, height=384, width=512
     sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.cast(255, dtype=sampling_mask_flatten.dtype)))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
-    gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
+    gt_flow_sampling_mask = tf.Variable(tf.boolean_mask(gt_flow, sampling_mask_rep), trainable=False)
     sparse_flow = tf.Variable(tf.reshape(sparse_flow, [-1]), trainable=False)
     sparse_flow = tf.scatter_update(sparse_flow, sampling_mask_flatten[0], gt_flow_sampling_mask)
     sparse_flow = tf.reshape(sparse_flow, gt_flow.shape)
@@ -318,7 +318,7 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.cast(255, dtype=sampling_mask_flatten.dtype)))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
-    gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
+    gt_flow_sampling_mask = tf.Variable(tf.boolean_mask(gt_flow, sampling_mask_rep), trainable=False)
     sparse_flow = tf.Variable(tf.reshape(sparse_flow, [-1]), trainable=False)
     sparse_flow = tf.scatter_update(sparse_flow, sampling_mask_flatten[0], gt_flow_sampling_mask)
     sparse_flow = tf.reshape(sparse_flow, gt_flow.shape)
@@ -327,11 +327,12 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
 
 
 def set_range_to_zero(matches, width, offset_h, offset_w, crop_h, crop_w):
-    range_rows = tf.range(offset_h, offset_h + crop_h)
-    range_cols = tf.range(offset_w, offset_w + crop_w)
+    range_rows = tf.range(offset_h, offset_h + crop_h, dtype=tf.int32)
+    range_cols = tf.range(offset_w, offset_w + crop_w, dtype=tf.int32)
+    print("range_rows.shape: {}\nrange_cols.shape: {}".format(range_rows.shape, range_cols.shape))
     # Get absolute indices as rows * width + cols
     indices = tf.add(tf.multiply(range_rows, width), range_cols)
-    zeros = tf.zeros(tf.shape(indices))
+    zeros = tf.Variable(tf.zeros(tf.shape(indices)), trainable=False)
     print("matches.shape: {}\nindices.shape: {}\nzeros.shape: {}".format(matches.shape, indices.shape, zeros.shape))
     print("type(matches): {}\ntype(indices): {}\ntype(zeros): {}".format(type(matches), type(indices), type(zeros)))
     matches = tf.scatter_update(matches, indices, zeros)
@@ -392,7 +393,7 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
 
     # Compute absolute indices as row * width + cols
     indices = tf.add(tf.multiply(rows_flatten, width), cols_flatten)
-    two_five_five = 255 * tf.ones(tf.shape(indices))
+    two_five_five = tf.Variable(255 * tf.ones(tf.shape(indices)), trainable=False)
     matches = tf.Variable(tf.reshape(matches, [-1]), trainable=False)
     # matches = np.zeros((height, width), dtype=np.int32)
 
@@ -417,7 +418,7 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
     sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.cast(255, dtype=sampling_mask_flatten.dtype)))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
-    gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
+    gt_flow_sampling_mask = tf.Variable(tf.boolean_mask(gt_flow, sampling_mask_rep), trainable=False)
     sparse_flow = tf.Variable(tf.reshape(sparse_flow, [-1]), trainable=False)
     sparse_flow = tf.scatter_update(sparse_flow, sampling_mask_flatten[0], gt_flow_sampling_mask)
     sparse_flow = tf.reshape(sparse_flow, gt_flow.shape)

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -370,9 +370,11 @@ def sample_sparse_flow(dm_matches, dm_flow, gt_flow, num_ranges=6, num_distrib=3
         density = np.random.uniform(low=75., high=90.)  # tf.random_uniform([], minval=75., maxval=90., dtype=tf.float32)
     else:
         raise ValueError("FATAL: id should have been an integer within (0-5) but instead was {}".format(density_id))
+    print("density_id: {}\ndensity: {:.2f}%")
 
     # Select a distribution (random uniform, invalid like or grid like with holes
     distrib_id = np.random.choice(range(num_distrib+1))  # tf.random_uniform([], maxval=num_distrib, dtype=tf.int32)
+    print("distribution_id: {}")
     matches, sparse_flow = sample_from_distribution(distrib_id, density, dm_matches, dm_flow, gt_flow)
 
     return matches, sparse_flow

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -282,7 +282,7 @@ def sample_sparse_invalid_like(gt_flow, target_density=75, height=384, width=512
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
-    sampling_mask_flatten = tf.compat.v1.where_v2(tf.equal(sampling_mask_flatten, tf.constant(255)))
+    sampling_mask_flatten = tf.compat.v2.where(tf.equal(sampling_mask_flatten, tf.constant(255)))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
@@ -315,7 +315,7 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
-    sampling_mask_flatten = tf.compat.v1.where_v2(tf.equal(sampling_mask_flatten, tf.constant(255)))
+    sampling_mask_flatten = tf.compat.v2.where(tf.equal(sampling_mask_flatten, tf.constant(255)))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
@@ -413,7 +413,7 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
-    sampling_mask_flatten = tf.compat.v1.where_v2(tf.equal(sampling_mask_flatten, tf.constant(255)))
+    sampling_mask_flatten = tf.compat.v2.where(tf.equal(sampling_mask_flatten, tf.constant(255)))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -210,13 +210,13 @@ def sample_gt_flow_to_sparse(gt_flow, target_density=75, target_distribution='un
     if target_distribution.lower() == 'uniform':
         sampling_mask = np.random.choice([0, 1], size=gt_flow.shape[:-1], p=[1 - p_fill, p_fill]).astype(
             np.int32)
-        sampling_mask = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
-        sampling_mask = np.reshape(sampling_mask, [-1])
-        sampling_mask = np.where(sampling_mask == 1)
+        sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
+        sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
+        sampling_mask_flatten = np.where(sampling_mask_flatten == 1)
 
-    gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask)
+    gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
     sparse_flow = tf.Variable(tf.reshape(sparse_flow, [-1]), trainable=False)
-    sparse_flow = tf.scatter_update(sparse_flow, sampling_mask[0], gt_flow_sampling_mask)
+    sparse_flow = tf.scatter_update(sparse_flow, sampling_mask_flatten[0], gt_flow_sampling_mask)
     sparse_flow = tf.reshape(sparse_flow, gt_flow.shape)
 
     return sparse_flow, gt_flow

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -373,7 +373,7 @@ def sample_sparse_flow(dm_matches, dm_flow, gt_flow, num_ranges=6, num_distrib=3
     print("density_id: {}\ndensity: {:.2f}%")
 
     # Select a distribution (random uniform, invalid like or grid like with holes
-    distrib_id = np.random.choice(range(num_distrib+1))  # tf.random_uniform([], maxval=num_distrib, dtype=tf.int32)
+    distrib_id = np.random.choice(range(num_distrib))  # tf.random_uniform([], maxval=num_distrib, dtype=tf.int32)
     print("distribution_id: {}")
     matches, sparse_flow = sample_from_distribution(distrib_id, density, dm_matches, dm_flow, gt_flow)
 

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -203,13 +203,13 @@ def sample_gt_flow_to_sparse(gt_flow, target_density=75, target_distribution='un
     # sparse_flow = tf.zeros(tf.shape(gt_flow), dtype=tf.float32)
     # sess = tf.Session()
     # sess.run(tf.constant(gt_flow))
-    sparse_flow = np.expand_dims(np.zeros(gt_flow.shape).astype(np.float32), axis=0)
+    sparse_flow = np.zeros(gt_flow.shape).astype(np.float32)
     p_fill = target_density / 100  # target_density expressed in %
     if target_distribution.lower() == 'uniform':
       sampling_mask = np.random.choice([0, 255], size=gt_flow.shape[:-1], p=[1 - p_fill, p_fill]).astype(
                     np.uint8)
       random_mask = sampling_mask == 255
-      random_mask_rep = np.expand_dims(np.repeat(random_mask[:, :, np.newaxis], 2, axis=2), axis=0)
+      random_mask_rep = np.repeat(random_mask[:, :, :, np.newaxis], 2, axis=-1)
       #tf.print(sampling_mask)
 #       sampling_mask_logical = sampling_mask == 1
 #       pixel_idxs = np.where(sampling_mask == 1)

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -356,9 +356,13 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
 def set_range_to_zero(matches, width, offset_h, offset_w, crop_h, crop_w):
     range_rows = tf.range(offset_h, offset_h + crop_h, dtype=tf.int32)
     range_cols = tf.range(offset_w, offset_w + crop_w, dtype=tf.int32)
-    print("range_rows.shape: {}\nrange_cols.shape: {}".format(range_rows.shape, range_cols.shape))
+    print("range_rows: {}\nrange_cols: {}".format(range_rows, range_cols))
+    rows, cols = tf.meshgrid(range_rows, range_cols)
+    rows_flatten = tf.reshape(rows, [-1])
+    cols_flatten = tf.reshape(cols, [-1])
+
     # Get absolute indices as rows * width + cols
-    indices = tf.add(tf.multiply(range_rows, width), range_cols)
+    indices = tf.add(tf.multiply(rows_flatten, width), cols_flatten)
     zeros = tf.zeros(tf.shape(indices), dtype=tf.float32)
     print("matches.shape: {}\nindices.shape: {}\nzeros.shape: {}".format(matches.shape, indices.shape, zeros.shape))
     print("type(matches): {}\ntype(indices): {}\ntype(zeros): {}".format(type(matches), type(indices), type(zeros)))

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -418,7 +418,7 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
     sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.cast(255, dtype=sampling_mask_flatten.dtype)))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
-    gt_flow_sampling_mask = tf.Variable(tf.boolean_mask(gt_flow, sampling_mask_rep), trainable=False)
+    gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
     sparse_flow = tf.Variable(tf.reshape(sparse_flow, [-1]), trainable=False)
     sparse_flow = tf.scatter_update(sparse_flow, sampling_mask_flatten[0], gt_flow_sampling_mask)
     sparse_flow = tf.reshape(sparse_flow, gt_flow.shape)

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -282,7 +282,7 @@ def sample_sparse_invalid_like(gt_flow, target_density=75, height=384, width=512
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
-    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.cast(255, dtype=tf.int32)))
+    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.cast(255, dtype=tf.float32)))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
@@ -315,7 +315,7 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
-    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.cast(255, dtype=tf.int32)))
+    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.cast(255, dtype=tf.float32)))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
@@ -414,7 +414,7 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
-    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.cast(255, dtype=tf.int32)))
+    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.cast(255, dtype=tf.float32)))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -393,7 +393,7 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
 
     # Compute absolute indices as row * width + cols
     indices = tf.add(tf.multiply(rows_flatten, width), cols_flatten)
-    two_five_five = tf.Variable(255 * tf.ones(tf.shape(indices)), trainable=False)
+    two_five_five = tf.Variable(255 * tf.ones(tf.shape(indices)), trainable=False, validate_shape=False)
     matches = tf.Variable(tf.reshape(matches, [-1]), trainable=False)
     # matches = np.zeros((height, width), dtype=np.int32)
 

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -201,15 +201,15 @@ def flow_resize(flow, out_size, is_scale=True, method=0):
 def sample_gt_flow_to_sparse(gt_flow, target_density=75, target_distribution='uniform'):
     gt_flow_size = tf.cast(tf.shape(gt_flow)[1:-1], tf.int32)  # height and width only
     # sparse_flow = tf.zeros(tf.shape(gt_flow), dtype=tf.float32)
-    sess = tf.Session()
-    sess.run(tf.constant(gt_flow))
-    sparse_flow = np.zeros(gt_flow.shape).astype(np.float32)
+    # sess = tf.Session()
+    # sess.run(tf.constant(gt_flow))
+    sparse_flow = np.expand_dims(np.zeros(gt_flow.shape).astype(np.float32), axis=0)
     p_fill = target_density / 100  # target_density expressed in %
     if target_distribution.lower() == 'uniform':
       sampling_mask = np.random.choice([0, 255], size=gt_flow.shape[:-1], p=[1 - p_fill, p_fill]).astype(
                     np.uint8)
       random_mask = sampling_mask == 255
-      random_mask_rep = np.repeat(random_mask[:, :, np.newaxis], 2, axis=2)
+      random_mask_rep = np.expand_dims(np.repeat(random_mask[:, :, np.newaxis], 2, axis=2), axis=0)
       #tf.print(sampling_mask)
 #       sampling_mask_logical = sampling_mask == 1
 #       pixel_idxs = np.where(sampling_mask == 1)

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -237,10 +237,10 @@ def sample_sparse_invalid_like(gt_flow, target_density=75):
     rand_offset_h, rand_offset_w, crop_h, crop_w = get_random_offset_and_crop(gt_flow.shape[:-1], target_density)
 
     # Define matches as 0 inside the random bbox, 255s elsewhere (at training time the mask is normalised to [0,1])
-    matches = 255 * np.ones(gt_flow.shape[:-1], dtype=np.int32)
+    matches = 255 * np.ones(gt_flow.shape[:-1], dtype=np.int32)  # (h, w)
     matches[rand_offset_h:rand_offset_h + crop_h, rand_offset_w: rand_offset_w + crop_w] = 0
     sampling_mask = matches
-    matches = tf.cast(tf.expand_dims(matches, 0), dtype=tf.float32)  # convert to (h, w, 1)
+    matches = tf.cast(tf.expand_dims(matches, -1), dtype=tf.float32)  # convert to (h, w, 1)
     sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
     sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
@@ -265,8 +265,8 @@ def sample_sparse_uniform(gt_flow, target_density=75):
     sparse_flow = tf.Variable(tf.zeros(gt_flow.shape, dtype=tf.float32), trainable=False)
     p_fill = target_density / 100  # target_density expressed in %
     sampling_mask = np.random.choice([0, 255], size=gt_flow.shape[:-1], p=[1 - p_fill, p_fill]).astype(
-        np.int32)
-    matches = tf.cast(tf.expand_dims(255 * sampling_mask, 0), dtype=tf.float32)  # convert to (h, w, 1)
+        np.int32)  # sampling_mask.shape: (h, w)
+    matches = tf.cast(tf.expand_dims(255 * sampling_mask, -1), dtype=tf.float32)  # convert to (h, w, 1)
     sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
     sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
@@ -311,8 +311,8 @@ def sample_sparse_grid_like(gt_flow, target_density=75):
     if np.random.choice([0, 1]) == 0:
         rand_offset_h, rand_offset_w, crop_h, crop_w = get_random_offset_and_crop(gt_flow.shape[:-1], target_density)
         matches[rand_offset_h:rand_offset_h + crop_h, rand_offset_w: rand_offset_w + crop_w] = 0
-    sampling_mask = matches
-    matches = tf.cast(tf.expand_dims(matches, 0), dtype=tf.float32)  # convert to (h, w, 1)
+    sampling_mask = matches  # sampling_mask of size (h, w)
+    matches = tf.cast(tf.expand_dims(matches, -1), dtype=tf.float32)  # convert to (h, w, 1)
     # Sample ground truth flow with given map
     sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -250,7 +250,7 @@ def sample_sparse_invalid_like(gt_flow, target_density=75):
     sparse_flow = tf.scatter_update(sparse_flow, sampling_mask_flatten[0], gt_flow_sampling_mask)
     sparse_flow = tf.reshape(sparse_flow, gt_flow.shape)
 
-    return sparse_flow, matches
+    return matches, sparse_flow
 
 
 def sample_sparse_uniform(gt_flow, target_density=75):
@@ -276,7 +276,7 @@ def sample_sparse_uniform(gt_flow, target_density=75):
     sparse_flow = tf.scatter_update(sparse_flow, sampling_mask_flatten[0], gt_flow_sampling_mask)
     sparse_flow = tf.reshape(sparse_flow, gt_flow.shape)
 
-    return sparse_flow, matches
+    return matches, sparse_flow
 
 
 def sample_sparse_grid_like(gt_flow, target_density=75):
@@ -323,7 +323,7 @@ def sample_sparse_grid_like(gt_flow, target_density=75):
     sparse_flow = tf.scatter_update(sparse_flow, sampling_mask_flatten[0], gt_flow_sampling_mask)
     sparse_flow = tf.reshape(sparse_flow, gt_flow.shape)
 
-    return sparse_flow, matches
+    return matches, sparse_flow
 
 
 def sample_from_distribution(distrib_id, density, dm_matches, dm_flow, gt_flow):
@@ -333,17 +333,17 @@ def sample_from_distribution(distrib_id, density, dm_matches, dm_flow, gt_flow):
             sparse_flow = dm_flow
             matches = dm_matches
         else:
-            sparse_flow, matches = sample_sparse_grid_like(gt_flow, target_density=density)
+            matches, sparse_flow = sample_sparse_grid_like(gt_flow, target_density=density)
 
     elif distrib_id == 1:
-        sparse_flow, matches = sample_sparse_uniform(gt_flow, target_density=density)
+        matches, sparse_flow = sample_sparse_uniform(gt_flow, target_density=density)
 
     elif distrib_id == 2:  # invalid-like (either 100% dense in known areas or 0% in unknown ones (holes))
-        sparse_flow, matches = sample_sparse_invalid_like(gt_flow, target_density=density)
+        matches, sparse_flow = sample_sparse_invalid_like(gt_flow, target_density=density)
     else:
         raise ValueError("FATAL: id should have been an integer within (0-5) but instead was {}".format(distrib_id))
 
-    return sparse_flow, matches
+    return matches, sparse_flow
 
 
 def sample_sparse_flow(dm_matches, dm_flow, gt_flow, num_ranges=6, num_distrib=3):

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -212,7 +212,7 @@ def sample_gt_flow_to_sparse(gt_flow, target_density=75, target_distribution='un
             np.uint8)
         random_mask = sampling_mask == 255
         print(random_mask.shape)
-        random_mask_rep = np.repeat(random_mask[:, :, :, np.newaxis], 2, axis=-1)
+        random_mask_rep = np.repeat(random_mask[:, :, np.newaxis], 2, axis=-1)
         print(random_mask_rep.shape)
         #tf.print(sampling_mask)
     #       sampling_mask_logical = sampling_mask == 1

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -487,9 +487,10 @@ def sample_sparse_flow(dm_matches, dm_flow, gt_flow, num_ranges=6, num_distrib=3
     """
     # Temporal checks
     print("dm_matches.shape: {}\ndm_matches.dtype: {}\ntf.unique(dm_matches)".format(dm_matches.shape, dm_matches.dtype,
-                                                                                     tf.unique(dm_matches)))
-    print("dm_flow.shape: {}\ndm_flow.dtype: {}\ntf.unique(dm_flow)".format(dm_flow.shape, dm_flow.dtype,
-                                                                            tf.unique(dm_flow)))
+                                                                                     tf.unique(tf.reshape(dm_matches,
+                                                                                                          [-1]))))
+    print("dm_flow.shape: {}\ndm_flow.dtype: {}\ntf.reduce_mean(dm_flow)".format(dm_flow.shape, dm_flow.dtype,
+                                                                                 tf.reduce_mean(dm_flow)))
     density = tf.zeros([], dtype=tf.float32)
     density = apply_with_random_selector(density, lambda x, ordering: get_sampling_density(x, ordering, fast_mode),
                                          num_cases=num_ranges)

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -225,7 +225,7 @@ def get_random_offset_and_crop(image_shape, density):
     :return:
     """
     p_fill = tf.divide(density, 100.0)  # target_density expressed in %
-    bbox_area = tf.multiply(p_fill, tf.multiply(image_shape[0], image_shape[1]))
+    bbox_area = tf.multiply(p_fill, tf.cast(tf.multiply(image_shape[0], image_shape[1]), dtype=tf.float32))
     num_aspect_ratios = 5
     # aspect_ratios = [16 / 9, 4 / 3, 3 / 2, 3 / 1, 4 / 5]
     aspect_ratios = tf.constant([16 / 9, 4 / 3, 3 / 2, 3 / 1, 4 / 5])

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -317,6 +317,8 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     print("after flatten: sampling_mask_flatten.shape: {}".format(sampling_mask_flatten.shape))
+    uniq, uniq_idx = tf.unique(sampling_mask_flatten)
+    print("tf.unique(sampling_mask_flatten): {}\nsampling_mask_flatten.dtype: {}".format(uniq, sampling_mask_flatten.dtype))
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
     sampling_mask_flatten_where = tf.where(tf.equal(sampling_mask_flatten, tf.cast(1, dtype=sampling_mask_flatten.dtype)))
     print("after tf.where: sampling_mask_flatten_where.shape: {}".format(sampling_mask_flatten_where.shape))

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -233,8 +233,8 @@ def sample_sparse_invalid_like(gt_flow, target_density=75, height=384, width=512
     :param target_density:
     :return:
     """
-    sparse_flow = tf.Variable(tf.zeros(gt_flow.shape, dtype=tf.float32), trainable=False)
-    rand_offset_h, rand_offset_w, crop_h, crop_w = get_random_offset_and_crop(gt_flow.shape[:-1], target_density)
+    sparse_flow = tf.Variable(tf.zeros((height, width), dtype=tf.float32), trainable=False)
+    rand_offset_h, rand_offset_w, crop_h, crop_w = get_random_offset_and_crop((height, width), target_density)
 
     # Define matches as 0 inside the random bbox, 255s elsewhere (at training time the mask is normalised to [0,1])
     matches = 255 * np.ones((height, width), dtype=np.int32)  # (h, w)
@@ -288,7 +288,7 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
     """
     sparse_flow = tf.Variable(tf.zeros((height, width), dtype=tf.float32), trainable=False)
     num_samples = (target_density / 100) * height * width
-    aspect_ratio = gt_flow.shape[1] / height
+    aspect_ratio = width / height
     # Compute as in invalid_like for a random box to know the number of samples in horizontal and vertical
     num_samples_w = int(np.round(np.sqrt(num_samples * aspect_ratio)))
     num_samples_h = int(np.round(num_samples_w / aspect_ratio))
@@ -301,7 +301,7 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
     sample_points_h = np.linspace(0, height - 1, num_samples_h, dtype=np.int32)
     sample_points_w = np.linspace(0, width - 1, num_samples_w, dtype=np.int32)
     # Create meshgrid of all combinations (i.e.: coordinates to sample at)
-    matches = np.zeros(gt_flow.shape[:-1], dtype=np.uint8)
+    matches = np.zeros((height, width), dtype=np.uint8)
     xx, yy = np.meshgrid(sample_points_w, sample_points_h)
     xx_flatten = xx.flatten()
     yy_flatten = yy.flatten()

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -370,7 +370,7 @@ def return_identity(x, y):
 def sample_from_distribution(distrib_id, density, dm_matches, dm_flow, gt_flow):
     height, width, _ = gt_flow.get_shape().as_list()
     sample_dm = tf.cond(tf.logical_and(tf.random_uniform([], maxval=2, dtype=tf.int32),  # 0 or 1
-                        tf.less_equal(density, tf.constant(1))), lambda: tf.constant(True), lambda: tf.constant(False))
+                        tf.less_equal(density, tf.constant(1.0))), lambda: tf.constant(True), lambda: tf.constant(False))
     # sample_dm = tf.cond(True if (np.random.choice([0, 1]) > 0 and density <= 1) else False  # tf.random_uniform([], maxval=2, dtype=tf.int32)  # 0 or 1
     tf.print("sample_dm: {}".format(sample_dm))
     tf.print("distrib_id: {}".format(distrib_id))

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -268,10 +268,11 @@ def sample_sparse_invalid_like(gt_flow, target_density=75, height=384, width=512
     rand_offset_h, rand_offset_w, crop_h, crop_w = get_random_offset_and_crop((height, width), target_density)
 
     # Define matches as 0 inside the random bbox, 1s elsewhere
-    matches = tf.ones((height, width), dtype=tf.float32)
+    ones = lambda: tf.ones((height * width), dtype=tf.float32)
     # matches = np.ones((height, width), dtype=np.int32)  # (h, w)
     # Assumption: matches is already a flatten array (when inputted to set_range...)
-    matches = tf.Variable(tf.reshape(matches, [-1]), trainable=False)
+    matches = tf.Variable(initial_value=ones, dtype=tf.float32, trainable=False)
+    # matches = tf.Variable(tf.reshape(matches, [-1]), trainable=False)
     matches = set_range_to_zero(matches, width, rand_offset_h, rand_offset_w, crop_h, crop_w)
     # Convert back to (height, width)
     matches = tf.reshape(matches, (height, width))
@@ -323,7 +324,7 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     print("after flatten: sampling_mask_flatten.shape: {}".format(sampling_mask_flatten.shape))
-    uniq, uniq_idx = tf.unique(sampling_mask_flatten)
+    uniq = tf.unique(sampling_mask_flatten)
     print("tf.unique(sampling_mask_flatten): {}\nsampling_mask_flatten.dtype: {}".format(uniq, sampling_mask_flatten.dtype))
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
     sampling_mask_flatten_where = tf.where(tf.equal(sampling_mask_flatten, tf.cast(1, dtype=sampling_mask_flatten.dtype)))

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -204,11 +204,14 @@ def sample_gt_flow_to_sparse(gt_flow, target_density=75, target_distribution='un
     # sess = tf.Session()
     # sess.run(tf.constant(gt_flow))
     sparse_flow = np.zeros(gt_flow.shape).astype(np.float32)
+    print(sparse_flow.shape)
+
     p_fill = target_density / 100  # target_density expressed in %
     if target_distribution.lower() == 'uniform':
         sampling_mask = np.random.choice([0, 255], size=gt_flow.shape[:-1], p=[1 - p_fill, p_fill]).astype(
             np.uint8)
         random_mask = sampling_mask == 255
+        print(random_mask.shape)
         random_mask_rep = np.repeat(random_mask[:, :, :, np.newaxis], 2, axis=-1)
         print(random_mask_rep.shape)
         #tf.print(sampling_mask)

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -209,6 +209,7 @@ def sample_gt_flow_to_sparse(gt_flow, target_density=75, target_distribution='un
       sampling_mask = np.random.choice([0, 255], size=gt_flow.shape[:-1], p=[1 - p_fill, p_fill]).astype(
                     np.uint8)
       random_mask = sampling_mask == 255
+      tf.print(gt_flow.shape)
       random_mask_rep = np.repeat(random_mask[:, :, :, np.newaxis], 2, axis=-1)
       #tf.print(sampling_mask)
 #       sampling_mask_logical = sampling_mask == 1

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -419,7 +419,7 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
     # Compute absolute indices as row * width + cols
     indices = tf.add(tf.multiply(rows_flatten, width), cols_flatten)
     ones_raw = lambda: tf.ones(tf.shape(indices))
-    ones = tf.Variable(init_value=ones_raw, trainable=False, validate_shape=False)
+    ones = tf.Variable(initial_value=ones_raw, trainable=False, validate_shape=False)
     matches = tf.Variable(tf.reshape(matches, [-1]), trainable=False)
     # matches = np.zeros((height, width), dtype=np.int32)
 

--- a/src/data_augmentation.py
+++ b/src/data_augmentation.py
@@ -282,7 +282,7 @@ def sample_sparse_invalid_like(gt_flow, target_density=75, height=384, width=512
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
-    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.constant(255)))
+    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, 255.0))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
@@ -315,7 +315,7 @@ def sample_sparse_uniform(gt_flow, target_density=75, height=384, width=512):
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
-    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.constant(255)))
+    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, 255.0))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)
@@ -413,7 +413,7 @@ def sample_sparse_grid_like(gt_flow, target_density=75, height=384, width=512):
     # sampling_mask_rep = np.repeat(sampling_mask[:, :, np.newaxis], 2, axis=-1)
     sampling_mask_flatten = tf.reshape(sampling_mask_rep, [-1])
     # sampling_mask_flatten = np.reshape(sampling_mask_rep, [-1])
-    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, tf.constant(255)))
+    sampling_mask_flatten = tf.where(tf.equal(sampling_mask_flatten, 255.0))
     # sampling_mask_flatten = np.where(sampling_mask_flatten == 255)
 
     gt_flow_sampling_mask = tf.boolean_mask(gt_flow, sampling_mask_rep)

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -35,7 +35,7 @@ def augment_all_interp(image, matches, sparse_flow, edges, gt_flow, crop_h, crop
     tf.print("global_step: {}".format(global_step))
     # Check if we can get global step value without explicitly passing it in which broke restoration from checkpoint
     # print("global_step.eval()".format(tf.train.get_global_step(graph=None).eval()))
-    sparse_flow, matches = sample_gt_flow_to_sparse(gt_flow)
+    # sparse_flow, matches = sample_gt_flow_to_sparse(gt_flow)
     # image, matches, sparse_flow, edges, gt_flow = random_crop([image, matches, sparse_flow, edges, gt_flow], crop_h,
     #                                                           crop_w)
     # Random flip of images and flow

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -31,7 +31,7 @@ def augment_image_pair(img1, img2, crop_h, crop_w):
 def augment_all_interp(image, matches, sparse_flow, edges, gt_flow, crop_h, crop_w, add_summary=False, fast_mode=False,
                        global_step=None):
     print_out = tf.cond(tf.equal(global_step, tf.cast(tf.constant(0), tf.int64)), lambda: tf.print(global_step),
-                        lambda: print("Not 0"))
+                        lambda: tf.print("Not 0"))
     # Check if we can get global step value without explicitly passing it in which broke restoration from checkpoint
     # print("global_step.eval()".format(tf.train.get_global_step(graph=None).eval()))
     sparse_flow = sample_gt_flow_to_sparse(gt_flow)

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -35,7 +35,7 @@ def augment_all_interp(image, matches, sparse_flow, edges, gt_flow, crop_h, crop
     # tf.print("global_step: {}".format(global_step))
     # Check if we can get global step value without explicitly passing it in which broke restoration from checkpoint
     # print("global_step.eval()".format(tf.train.get_global_step(graph=None).eval()))
-    # matches, sparse_flow = sample_sparse_flow(matches, sparse_flow, gt_flow)
+    matches, sparse_flow = sample_sparse_flow(matches, sparse_flow, gt_flow)
     # image, matches, sparse_flow, edges, gt_flow = random_crop([image, matches, sparse_flow, edges, gt_flow], crop_h,
     #                                                           crop_w)
     # Random flip of images and flow

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -34,7 +34,7 @@ def augment_all_interp(image, matches, sparse_flow, edges, gt_flow, crop_h, crop
                         lambda: tf.print("Not 0"))
     # Check if we can get global step value without explicitly passing it in which broke restoration from checkpoint
     # print("global_step.eval()".format(tf.train.get_global_step(graph=None).eval()))
-    sparse_flow = sample_gt_flow_to_sparse(gt_flow)
+    sparse_flow, gt_flow = sample_gt_flow_to_sparse(gt_flow)
     # image, matches, sparse_flow, edges, gt_flow = random_crop([image, matches, sparse_flow, edges, gt_flow], crop_h,
     #                                                           crop_w)
     # Random flip of images and flow

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -28,9 +28,12 @@ def augment_image_pair(img1, img2, crop_h, crop_w):
 # add_summary shows images when they are being augmented (that is, several images from the same batch)
 # This might be too verbose once we known the augmentations work as expected since the train/image_a, etc. are augmented
 # already and shown in TB by default
-def augment_all_interp(image, matches, sparse_flow, edges, gt_flow, crop_h, crop_w, add_summary=False, fast_mode=False):
+def augment_all_interp(image, matches, sparse_flow, edges, gt_flow, crop_h, crop_w, add_summary=False, fast_mode=False,
+                       global_step=None):
+    print_out = tf.cond(tf.equal(global_step, tf.constant(0)), lambda: tf.print(global_step), lambda: print("Not 0"))
     # Check if we can get global step value without explicitly passing it in which broke restoration from checkpoint
     # print("global_step.eval()".format(tf.train.get_global_step(graph=None).eval()))
+    sparse_flow = sample_gt_flow_to_sparse(gt_flow)
     # image, matches, sparse_flow, edges, gt_flow = random_crop([image, matches, sparse_flow, edges, gt_flow], crop_h,
     #                                                           crop_w)
     # Random flip of images and flow
@@ -425,7 +428,7 @@ def load_batch(dataset_config_str, split_name, global_step=None, input_type='ima
                 print("(image_matches) Applying data augmentation...")  # temporally to debug
                 image_a, matches_a, sparse_flow, edges_a, flow = augment_all_interp(
                     image_a, matches_a, sparse_flow, edges_a, flow, crop_h=crop[0], crop_w=crop[1],
-                    add_summary=add_summary_augmentation, fast_mode=False)
+                    add_summary=add_summary_augmentation, fast_mode=False, global_step=global_step)
 
             # Add extra 'batching' dimension
             image_bs = None

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -32,9 +32,10 @@ def augment_all_interp(image, matches, sparse_flow, edges, gt_flow, crop_h, crop
                        global_step=None):
     print_out = tf.cond(tf.equal(global_step, tf.cast(tf.constant(0), tf.int64)),
                         lambda: tf.print("global_step: {}".format(global_step)), lambda: tf.print("Not 0"))
+    tf.print("global_step: {}".format(global_step))
     # Check if we can get global step value without explicitly passing it in which broke restoration from checkpoint
     # print("global_step.eval()".format(tf.train.get_global_step(graph=None).eval()))
-    sparse_flow, gt_flow = sample_gt_flow_to_sparse(gt_flow)
+    sparse_flow, matches = sample_gt_flow_to_sparse(gt_flow)
     # image, matches, sparse_flow, edges, gt_flow = random_crop([image, matches, sparse_flow, edges, gt_flow], crop_h,
     #                                                           crop_w)
     # Random flip of images and flow

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -35,7 +35,7 @@ def augment_all_interp(image, matches, sparse_flow, edges, gt_flow, crop_h, crop
     # tf.print("global_step: {}".format(global_step))
     # Check if we can get global step value without explicitly passing it in which broke restoration from checkpoint
     # print("global_step.eval()".format(tf.train.get_global_step(graph=None).eval()))
-    sparse_flow, matches = sample_sparse_flow(matches, sparse_flow, gt_flow)
+    matches, sparse_flow = sample_sparse_flow(matches, sparse_flow, gt_flow)
     # image, matches, sparse_flow, edges, gt_flow = random_crop([image, matches, sparse_flow, edges, gt_flow], crop_h,
     #                                                           crop_w)
     # Random flip of images and flow

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -35,7 +35,7 @@ def augment_all_interp(image, matches, sparse_flow, edges, gt_flow, crop_h, crop
     # tf.print("global_step: {}".format(global_step))
     # Check if we can get global step value without explicitly passing it in which broke restoration from checkpoint
     # print("global_step.eval()".format(tf.train.get_global_step(graph=None).eval()))
-    matches, sparse_flow = sample_sparse_flow(matches, sparse_flow, gt_flow)
+    matches, sparse_flow = sample_sparse_flow(matches, sparse_flow, gt_flow, fast_mode=False)
     # image, matches, sparse_flow, edges, gt_flow = random_crop([image, matches, sparse_flow, edges, gt_flow], crop_h,
     #                                                           crop_w)
     # Random flip of images and flow

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -30,12 +30,12 @@ def augment_image_pair(img1, img2, crop_h, crop_w):
 # already and shown in TB by default
 def augment_all_interp(image, matches, sparse_flow, edges, gt_flow, crop_h, crop_w, add_summary=False, fast_mode=False,
                        global_step=None):
-    print_out = tf.cond(tf.equal(global_step, tf.cast(tf.constant(0), tf.int64)),
-                        lambda: tf.print("global_step: {}".format(global_step)), lambda: tf.print("Not 0"))
-    tf.print("global_step: {}".format(global_step))
+    # print_out = tf.cond(tf.equal(global_step, tf.cast(tf.constant(0), tf.int64)),
+    #                     lambda: tf.print("global_step: {}".format(global_step)), lambda: tf.print("Not 0"))
+    # tf.print("global_step: {}".format(global_step))
     # Check if we can get global step value without explicitly passing it in which broke restoration from checkpoint
     # print("global_step.eval()".format(tf.train.get_global_step(graph=None).eval()))
-    # sparse_flow, matches = sample_gt_flow_to_sparse(gt_flow)
+    sparse_flow, matches = sample_sparse_flow(matches, sparse_flow, gt_flow)
     # image, matches, sparse_flow, edges, gt_flow = random_crop([image, matches, sparse_flow, edges, gt_flow], crop_h,
     #                                                           crop_w)
     # Random flip of images and flow

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -35,7 +35,7 @@ def augment_all_interp(image, matches, sparse_flow, edges, gt_flow, crop_h, crop
     # tf.print("global_step: {}".format(global_step))
     # Check if we can get global step value without explicitly passing it in which broke restoration from checkpoint
     # print("global_step.eval()".format(tf.train.get_global_step(graph=None).eval()))
-    matches, sparse_flow = sample_sparse_flow(matches, sparse_flow, gt_flow)
+    # matches, sparse_flow = sample_sparse_flow(matches, sparse_flow, gt_flow)
     # image, matches, sparse_flow, edges, gt_flow = random_crop([image, matches, sparse_flow, edges, gt_flow], crop_h,
     #                                                           crop_w)
     # Random flip of images and flow

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -30,8 +30,8 @@ def augment_image_pair(img1, img2, crop_h, crop_w):
 # already and shown in TB by default
 def augment_all_interp(image, matches, sparse_flow, edges, gt_flow, crop_h, crop_w, add_summary=False, fast_mode=False,
                        global_step=None):
-    print_out = tf.cond(tf.equal(global_step, tf.cast(tf.constant(0), tf.int64)), lambda: tf.print(global_step),
-                        lambda: tf.print("Not 0"))
+    print_out = tf.cond(tf.equal(global_step, tf.cast(tf.constant(0), tf.int64)),
+                        lambda: tf.print("global_step: {}".format(global_step)), lambda: tf.print("Not 0"))
     # Check if we can get global step value without explicitly passing it in which broke restoration from checkpoint
     # print("global_step.eval()".format(tf.train.get_global_step(graph=None).eval()))
     sparse_flow, gt_flow = sample_gt_flow_to_sparse(gt_flow)

--- a/src/dataloader.py
+++ b/src/dataloader.py
@@ -30,7 +30,8 @@ def augment_image_pair(img1, img2, crop_h, crop_w):
 # already and shown in TB by default
 def augment_all_interp(image, matches, sparse_flow, edges, gt_flow, crop_h, crop_w, add_summary=False, fast_mode=False,
                        global_step=None):
-    print_out = tf.cond(tf.equal(global_step, tf.constant(0)), lambda: tf.print(global_step), lambda: print("Not 0"))
+    print_out = tf.cond(tf.equal(global_step, tf.cast(tf.constant(0), tf.int64)), lambda: tf.print(global_step),
+                        lambda: print("Not 0"))
     # Check if we can get global step value without explicitly passing it in which broke restoration from checkpoint
     # print("global_step.eval()".format(tf.train.get_global_step(graph=None).eval()))
     sparse_flow = sample_gt_flow_to_sparse(gt_flow)

--- a/src/flownet_s_interp/flownet_s_interp.py
+++ b/src/flownet_s_interp/flownet_s_interp.py
@@ -1,5 +1,5 @@
 from ..net import Net, Mode
-from ..utils import LeakyReLU, average_endpoint_error_hfem, pad, antipad
+from ..utils import LeakyReLU, average_endpoint_error_hfem, average_endpoint_error, pad, antipad
 from ..downsample import downsample
 import math
 import tensorflow as tf
@@ -248,4 +248,7 @@ class FlowNetS_interp(Net):
         # Default collection is tf.GraphKeys.LOSSES (used for training, another one for validation)
         tf.losses.add_loss(loss)  # without this it worked despite TF strongly recommending this for custom losses
         # Return the 'total' loss: loss fns + regularization terms defined in the model
-        return tf.losses.get_total_loss()
+
+        # Compute AEPE after upsampling to get an analytical estimation of the final results
+        AEPE = average_endpoint_error(targets, predictions['flow'])
+        return tf.losses.get_total_loss(), AEPE

--- a/src/flownet_s_interp/flownet_s_interp.py
+++ b/src/flownet_s_interp/flownet_s_interp.py
@@ -1,5 +1,5 @@
 from ..net import Net, Mode
-from ..utils import LeakyReLU, average_endpoint_error_hfem, average_endpoint_error, pad, antipad
+from ..utils import LeakyReLU, average_endpoint_error_hfem, mean_endpoint_error, pad, antipad
 from ..downsample import downsample
 import math
 import tensorflow as tf
@@ -250,5 +250,5 @@ class FlowNetS_interp(Net):
         # Return the 'total' loss: loss fns + regularization terms defined in the model
 
         # Compute AEPE after upsampling to get an analytical estimation of the final results
-        AEPE = average_endpoint_error(targets, predictions['flow'])
+        AEPE = mean_endpoint_error(targets, predictions['flow'])
         return tf.losses.get_total_loss(), AEPE

--- a/src/flownet_s_interp/train.py
+++ b/src/flownet_s_interp/train.py
@@ -2,12 +2,15 @@ from ..dataloader import load_batch
 from .flownet_s_interp import FlowNetS_interp
 import argparse
 from ..utils import str2bool
+import tensorflow as tf
 
 
 # TODO: update traning scripts for all other architectures with latest changes
 def main():
     # Create a new network
     net = FlowNetS_interp(no_deconv_biases=FLAGS.no_deconv_biases)
+    # Create global step here so we can track it from load_batch AND train
+    global_step_tensor = tf.Variable(0, trainable=False, name='global_step', dtype=tf.int64)
     if FLAGS.checkpoint is not None and FLAGS.checkpoint:  # the second checks if the string is NOT empty
         print("Checkpoint path is NOT empty, parsing it...")
         print("ckpt_path: {}".format(FLAGS.checkpoint))
@@ -88,7 +91,8 @@ def main():
             capacity_in_batches_val=FLAGS.capacity_in_batches_val,
             batch_size=FLAGS.batch_size,
             data_augmentation=FLAGS.data_augmentation,
-            add_summary_augmentation=FLAGS.log_tensorboard,)
+            add_summary_augmentation=FLAGS.log_tensorboard,
+            global_step=global_step_tensor,)
         if train_params_dict is not None:
             train_params_dict['eff_batch_size'] = FLAGS.batch_size
 
@@ -139,7 +143,8 @@ def main():
             add_hfem=FLAGS.add_hard_flow_example_mining,
             lambda_w=FLAGS.hfem_lambda_w,
             hfem_perc=FLAGS.hfem_perc_hard,
-            dataset_config_str=FLAGS.dataset_config,)
+            dataset_config_str=FLAGS.dataset_config,
+            global_step_tensor=global_step_tensor,)
     else:
         print("Input_type: 'image_pairs'")
         # Train
@@ -152,7 +157,8 @@ def main():
             capacity_in_batches_val=FLAGS.capacity_in_batches_val,
             batch_size=FLAGS.batch_size,
             data_augmentation=FLAGS.data_augmentation,
-            add_summary_augmentation=FLAGS.log_tensorboard, )
+            add_summary_augmentation=FLAGS.log_tensorboard,
+            global_step=global_step_tensor,)
         if train_params_dict is not None:
             train_params_dict['eff_batch_size'] = FLAGS.batch_size
 
@@ -166,7 +172,8 @@ def main():
                 capacity_in_batches_train=FLAGS.capacity_in_batches_train,
                 capacity_in_batches_val=FLAGS.capacity_in_batches_val,
                 batch_size=FLAGS.batch_size,
-                data_augmentation=False,)  # just in case as we already filter by split_name
+                data_augmentation=False,
+                global_step=global_step_tensor,)  # just in case as we already filter by split_name
 
         else:
             val_input_a = None
@@ -197,7 +204,7 @@ def main():
             lambda_w=FLAGS.hfem_lambda_w,
             hfem_perc=FLAGS.hfem_perc_hard,
             dataset_config_str=FLAGS.dataset_config,
-        )
+            global_step_tensor=global_step_tensor,)
 
 
 # TODO: think a better way to generate the dictionaries of training parameters (not fixed, step-wise policies)

--- a/src/flownet_s_interp/train.py
+++ b/src/flownet_s_interp/train.py
@@ -9,8 +9,7 @@ import tensorflow as tf
 def main():
     # Create a new network
     net = FlowNetS_interp(no_deconv_biases=FLAGS.no_deconv_biases)
-    # Create global step here so we can track it from load_batch AND train
-    global_step_tensor = tf.Variable(0, trainable=False, name='global_step', dtype=tf.int64)
+
     if FLAGS.checkpoint is not None and FLAGS.checkpoint:  # the second checks if the string is NOT empty
         print("Checkpoint path is NOT empty, parsing it...")
         print("ckpt_path: {}".format(FLAGS.checkpoint))
@@ -18,6 +17,12 @@ def main():
     else:
         print("Checkpoint IS empty, will train from scratch!")
         checkpoints = None  # double-check None
+    # Create global step here so we can track it from load_batch AND train
+    if FLAGS.reset_global_step:
+        global_step_tensor = tf.Variable(0, trainable=False, name='global_step', dtype=tf.int64)
+    else:
+        step_number = int(checkpoints.split('-')[-1])
+        global_step_tensor = tf.Variable(step_number, trainable=False, name='global_step', dtype=tf.int64)
 
     # initialise range test values (exponentially/linearly increasing lr to be tested)
     if FLAGS.lr_range_test and FLAGS.training_schedule.lower() == 'lr_range_test':

--- a/src/flownet_s_interp/train.py
+++ b/src/flownet_s_interp/train.py
@@ -21,8 +21,11 @@ def main():
     if FLAGS.reset_global_step:
         global_step_tensor = tf.Variable(0, trainable=False, name='global_step', dtype=tf.int64)
     else:
-        step_number = int(checkpoints.split('-')[-1])
-        global_step_tensor = tf.Variable(step_number, trainable=False, name='global_step', dtype=tf.int64)
+        if FLAGS.checkpoint is not None and FLAGS.checkpoint:
+            step_number = int(checkpoints.split('-')[-1])
+            global_step_tensor = tf.Variable(step_number, trainable=False, name='global_step', dtype=tf.int64)
+        else:
+            global_step_tensor = tf.Variable(0, trainable=False, name='global_step', dtype=tf.int64)
 
     # initialise range test values (exponentially/linearly increasing lr to be tested)
     if FLAGS.lr_range_test and FLAGS.training_schedule.lower() == 'lr_range_test':

--- a/src/net.py
+++ b/src/net.py
@@ -893,7 +893,7 @@ class Net(object):
               val_matches_a=None, val_sparse_flow=None, val_edges_a=None, checkpoints=None, input_type='image_pairs',
               log_verbosity=1, log_tensorboard=True, lr_range_test=False, train_params_dict=None,
               log_smoothed_loss=True, reset_global_step=False, summarise_grads=False, add_hfem='', lambda_w=2,
-              hfem_perc=50, dataset_config_str='flying_chairs'):
+              hfem_perc=50, dataset_config_str='flying_chairs', global_step_tensor=None):
 
         """
         runs training on the network from which this method is called.
@@ -925,9 +925,13 @@ class Net(object):
         :param lambda_w:
         :param hfem_perc:
         :param dataset_config_str:
+        :param global_step_tensor:
 
         :return:
         """
+        if global_step_tensor is None:
+            global_step_tensor = tf.Variable(0, trainable=False, name='global_step', dtype=tf.int64)
+
         if log_verbosity <= 1:  # print loss and tfinfo to stdout
             tf.logging.set_verbosity(tf.logging.INFO)
         else:  # debug info (more verbose)
@@ -985,8 +989,9 @@ class Net(object):
                     }
                 # Initialise checkpoint for stacked nets with the global step as the number of the outermost net
                 step_number = int(checkpoint_path.split('-')[-1])
-                checkpoint_global_step_tensor = tf.Variable(step_number, trainable=False, name='global_step',
-                                                            dtype=tf.int64)
+                # checkpoint_global_step_tensor = tf.Variable(step_number, trainable=False, name='global_step',
+                #                                             dtype=tf.int64)
+                global_step_tensor.assign(step_number)
             # TODO: adapt resuming from saver to stacked architectures
             elif isinstance(checkpoints, str):
                 checkpoint_path = checkpoints
@@ -996,16 +1001,19 @@ class Net(object):
                         print("Defining global step by parsing model filename...")
                         print("Found step number: {}".format(step_number))
 
-                    checkpoint_global_step_tensor = tf.Variable(step_number, trainable=False, name='global_step',
-                                                                dtype=tf.int64)
+                    # checkpoint_global_step_tensor = tf.Variable(step_number, trainable=False, name='global_step',
+                    #                                             dtype=tf.int64)
+                    global_step_tensor.assign(step_number)
                 else:
                     if log_verbosity > 1:
                         print("Defining global step as 0 (reset_global_step = True)")
-                    checkpoint_global_step_tensor = tf.Variable(0, trainable=False, name='global_step', dtype=tf.int64)
+                    # checkpoint_global_step_tensor = tf.Variable(0, trainable=False, name='global_step', dtype=tf.int64)
+                    global_step_tensor.assign(0)
             else:
                 raise ValueError("checkpoint should be a single path (string) or a dictionary for stacked networks")
         else:
-            checkpoint_global_step_tensor = tf.Variable(0, trainable=False, name='global_step', dtype=tf.int64)
+            # checkpoint_global_step_tensor = tf.Variable(0, trainable=False, name='global_step', dtype=tf.int64)
+            global_step_tensor.assign(0)
 
         # TODO: simplify (if possible) how we separate the step-wise policies (train_params_dict is None) vs the rest
         # max_steps overrides max_iter which is configured in training_schedules.py
@@ -1034,7 +1042,7 @@ class Net(object):
                 if log_verbosity:
                     print("max_iters: {}, min_lr: {:.4f}, max_lr: {:.4f}".format(training_schedule['max_iters'],
                                                                                  start_lr, end_lr))
-                learning_rate = exponentially_increasing_lr(checkpoint_global_step_tensor, min_lr=start_lr,
+                learning_rate = exponentially_increasing_lr(global_step_tensor, min_lr=start_lr,
                                                             max_lr=end_lr, num_iters=training_schedule['max_iters'])
             else:  # linear
                 if log_verbosity > 1:
@@ -1042,7 +1050,7 @@ class Net(object):
                     print("base learning rate: {}, maximum learning rate: {}, step_size: {}, max_iters: {}".format(
                         start_lr, end_lr, lr_range_niters, train_params_dict['max_steps']))
 
-                learning_rate = _lr_cyclic(g_step_op=checkpoint_global_step_tensor, base_lr=start_lr, max_lr=end_lr,
+                learning_rate = _lr_cyclic(g_step_op=global_step_tensor, base_lr=start_lr, max_lr=end_lr,
                                            step_size=lr_range_niters, mode='triangular')
 
         elif isinstance(training_schedule['learning_rates'], str) and not lr_range_test and \
@@ -1051,7 +1059,7 @@ class Net(object):
                 if log_verbosity > 1:
                     print("Learning rate policy is CLR (Cyclical Learning Rate)")
                 learning_rate = _lr_cyclic(
-                    g_step_op=checkpoint_global_step_tensor, base_lr=train_params_dict['clr_min_lr'],
+                    g_step_op=global_step_tensor, base_lr=train_params_dict['clr_min_lr'],
                     max_lr=train_params_dict['clr_max_lr'], step_size=train_params_dict['clr_stepsize'],
                     gamma=train_params_dict['clr_gamma'], mode=train_params_dict['clr_mode'])
                 # Change max_iter according to the number of cycles and stepsize
@@ -1065,7 +1073,7 @@ class Net(object):
                 if log_verbosity > 1:
                     print("Learning rate policy is 1-cycle (CLR with only 1 longer cycle + LR annealing at the end)")
                 learning_rate = _lr_cyclic(
-                    g_step_op=checkpoint_global_step_tensor, base_lr=train_params_dict['clr_min_lr'],
+                    g_step_op=global_step_tensor, base_lr=train_params_dict['clr_min_lr'],
                     max_lr=train_params_dict['clr_max_lr'], step_size=train_params_dict['clr_stepsize'],
                     mode='triangular', one_cycle=True, annealing_factor=train_params_dict['one_cycle_annealing_factor'])
                 # Define total length of the 1cycle + annealing by overwriting maximum number of iterations
@@ -1073,7 +1081,7 @@ class Net(object):
                 if log_verbosity > 1:
                     print("Training schedule is 'exp_decr' (exponentially decreasing LR)")
                 learning_rate = exponentially_decreasing_lr(
-                    checkpoint_global_step_tensor, min_lr=train_params_dict['end_lr'],
+                    global_step_tensor, min_lr=train_params_dict['end_lr'],
                     max_lr=train_params_dict['start_lr'], num_iters=training_schedule['max_iters'])
             else:
                 if log_verbosity > 1:
@@ -1083,7 +1091,7 @@ class Net(object):
         else:  #
             if log_verbosity > 1:
                 print("Piecewise constant learning selected (defined in 'training_schedules.py')")
-            learning_rate = tf.train.piecewise_constant(checkpoint_global_step_tensor,
+            learning_rate = tf.train.piecewise_constant(global_step_tensor,
                                                         [tf.cast(v, tf.int64) for v in training_schedule['step_values']],
                                                         training_schedule['learning_rates'])
         # TODO: define common variables outside of individual if-statements to keep it as short as possible
@@ -1111,7 +1119,7 @@ class Net(object):
                                 print("Cycle boundaries are: max={}, min={}".format(train_params_dict['max_momentum'],
                                                                                     train_params_dict['min_momentum']))
                             # Use cyclical momentum (only decreasing half-cycle while LR increases)
-                            momentum = _lr_cyclic(g_step_op=checkpoint_global_step_tensor,
+                            momentum = _lr_cyclic(g_step_op=global_step_tensor,
                                                   base_lr=train_params_dict['max_momentum'],
                                                   max_lr=train_params_dict['min_momentum'],
                                                   step_size=lr_range_niters,
@@ -1125,7 +1133,7 @@ class Net(object):
                                     train_params_dict['gamma'] = 1  # effectively disables (avoids duplicate code)
                                 else:
                                     is_one_cycle = False
-                            momentum = _mom_cyclic(g_step_op=checkpoint_global_step_tensor,
+                            momentum = _mom_cyclic(g_step_op=global_step_tensor,
                                                    base_mom=train_params_dict['min_momentum'],
                                                    max_mom=train_params_dict['max_momentum'],
                                                    gamma=train_params_dict['gamma'],
@@ -1255,7 +1263,7 @@ class Net(object):
 
         if reset_global_step:
             print("global_step has value: {}".format(tf.train.get_global_step()))
-            checkpoint_global_step_tensor.assign(0)
+            global_step_tensor.assign(0)
 
         if train_params_dict is not None:
             clip_grad_norm = train_params_dict['clip_grad_norm']
@@ -1266,7 +1274,7 @@ class Net(object):
             train_loss,
             optimizer,
             summarize_gradients=summarise_grads,
-            global_step=checkpoint_global_step_tensor,
+            global_step=global_step_tensor,
             clip_gradient_norm=clip_grad_norm,
         )
 
@@ -1320,8 +1328,9 @@ class Net(object):
                 init_assign_op, init_feed_dict = slim.assign_from_checkpoint(checkpoint_path, renamed_variables)
                 # Initialise checkpoint for stacked nets with the global step as the number of the outermost net
                 step_number = int(os.path.basename(checkpoint_path).split('-')[-1])
-                checkpoint_global_step_tensor = tf.Variable(step_number, trainable=False, name='global_step',
-                                                            dtype=tf.int64)
+                # checkpoint_global_step_tensor = tf.Variable(step_number, trainable=False, name='global_step',
+                #                                            dtype=tf.int64)
+                global_step_tensor.assign(step_number)
                 # TODO: adapt resuming from saver to stacked architectures
                 saver = None
             # TODO: double-check but it seems that if we remove the last checkpoint and keep and older point this fails
@@ -1383,7 +1392,7 @@ class Net(object):
                 slim.learning.train_step(
                     session,
                     training_op,
-                    checkpoint_global_step_tensor,
+                    global_step_tensor,
                     {'should_trace': tf.constant(1), 'should_log': tf.constant(1), 'logdir': debug_logdir, }
                 )
         else:
@@ -1401,7 +1410,7 @@ class Net(object):
                         log_dir,
                         # local_init_op=local_init_op,
                         # session_config=tf.ConfigProto(allow_soft_placement=True),
-                        global_step=checkpoint_global_step_tensor,
+                        global_step=global_step_tensor,
                         save_summaries_secs=save_summaries_secs,
                         save_interval_secs=save_interval_secs,
                         number_of_steps=training_schedule['max_iters'],
@@ -1417,7 +1426,7 @@ class Net(object):
                         log_dir,
                         # local_init_op=local_init_op,
                         # session_config=tf.ConfigProto(allow_soft_placement=True),
-                        global_step=checkpoint_global_step_tensor,
+                        global_step=global_step_tensor,
                         save_summaries_secs=save_summaries_secs,
                         save_interval_secs=save_interval_secs,
                         number_of_steps=training_schedule['max_iters'],
@@ -1431,7 +1440,7 @@ class Net(object):
                         training_op,
                         log_dir,
                         # session_config=tf.ConfigProto(allow_soft_placement=True),
-                        global_step=checkpoint_global_step_tensor,
+                        global_step=global_step_tensor,
                         save_summaries_secs=save_summaries_secs,
                         save_interval_secs=save_interval_secs,
                         number_of_steps=training_schedule['max_iters'],
@@ -1444,7 +1453,7 @@ class Net(object):
                         training_op,
                         log_dir,
                         # session_config=tf.ConfigProto(allow_soft_placement=True),
-                        global_step=checkpoint_global_step_tensor,
+                        global_step=global_step_tensor,
                         save_summaries_secs=save_summaries_secs,
                         save_interval_secs=save_interval_secs,
                         number_of_steps=training_schedule['max_iters'],

--- a/src/net.py
+++ b/src/net.py
@@ -266,7 +266,14 @@ class Net(object):
             event_string = 'Sfine_{0}_{1}_it={2}_BS{3}_opt_Adam_wd={4:.1e}HFEM_{5}_{6}'.format(
                 dataset_name, ckpt_str, step_number, eff_batch_size, training_schedule['l2_regularization'], add_hfem,
                 date_string)
-
+        elif 'sintel_s' in training_schedule_str.lower():  # LR disruptions from PWC-Net+ for MPI-Sintel
+            event_string = '{0}_{1}_it={2}_BS{3}_opt_Adam_wd={4:.1e}HFEM_{5}_{6}'.format(
+                training_schedule_str.lower(), ckpt_str, step_number, eff_batch_size,
+                training_schedule['l2_regularization'], add_hfem, date_string)
+        elif 'kitti_s' in training_schedule_str.lower():  # LR disruptions from PWC-Net+ for KITTI
+            event_string = '{0}_{1}_it={2}_BS{3}_opt_Adam_wd={4:.1e}HFEM_{5}_{6}'.format(
+                training_schedule_str.lower(), ckpt_str, step_number, eff_batch_size,
+                training_schedule['l2_regularization'], add_hfem, date_string)
         elif 'lr_range_test' in training_schedule_str.lower():
             if train_params_dict['lr_range_mode'] == 'linear':
                 total_iters = train_params_dict['lr_range_niters']

--- a/src/utils.py
+++ b/src/utils.py
@@ -316,6 +316,18 @@ def average_endpoint_error_hfem(labels, predictions, add_hfem='', lambda_w=2., p
         return aepe
 
 
+def average_endpoint_error(gt_flow, pred_flow):
+    """
+    Computes the mean average endpoint error (L2 norm) between a ground truth and a predicted flow
+    :param gt_flow:
+    :param pred_flow:
+    :return:
+    """
+    EPE = tf.norm(gt_flow - pred_flow, axis=-1, keepdims=True)
+    AEPE = tf.reduce_mean(EPE)
+    return AEPE
+
+
 # Losses from SelFlow, the top performing OF estimation method on Sintel (at the time of writing this)
 # They do an unsupervised training + supervised fine-tuning only on Sintel (no need to use FC or FT3D!)
 # The authors made their code available at: https://github.com/ppliuboy/SelFlow

--- a/src/utils.py
+++ b/src/utils.py
@@ -304,6 +304,8 @@ def average_endpoint_error_hfem(labels, predictions, add_hfem='', lambda_w=2., p
             epe_times_edges = tf.multiply(epe, edges)  # both have shape: (batch, height, width, 1)
             # Sum epe weighted by the edges and 'standard' epe and THEN sum and divide over batch size
             epe_and_edges = tf.add(epe, tf.multiply(lambda_w, epe_times_edges))
+            print("epe.shape: {}\nepe_times_edges.shape: {}\nepe_and_edges.shape: {}".format(epe, epe_times_edges,
+                                                                                             epe_and_edges))
 
             # Sum and divide by batch size
             epe_edges_sum = tf.reduce_sum(epe_and_edges)
@@ -316,7 +318,7 @@ def average_endpoint_error_hfem(labels, predictions, add_hfem='', lambda_w=2., p
         return aepe
 
 
-def average_endpoint_error(gt_flow, pred_flow):
+def mean_endpoint_error(gt_flow, pred_flow):
     """
     Computes the mean average endpoint error (L2 norm) between a ground truth and a predicted flow
     :param gt_flow:


### PR DESCRIPTION
Not all goals have been achieved at this point. We **can** train mixing densities by randomly sampling with different densities and distributions online.
**BUT**, we have not found an easy way to pass the global_step to the dataloader so we can gradually change from denser(easier) to sparser (harder) seeds. This is due to the code structure (separating the dataloader and the main training function + using tf.slim).

We will probably won't have time to complete this before delivering the thesis and hence it should be listed as future work.
Moreover, we have opened [an issue](https://github.com/ppliuboy/SelFlow/issues/5) to known which Superpixels implementations is used by the authors of SelFlow (there is a c++ one but it may be quite tricky to integrate it into the framework ATM), so we can generate more realistic holes in the initial seeds (e.g.: like occlusions, etc.).

We also have a bug when generating invalid_like seeds (with holes) and we will further investigate in in the master branch!

